### PR TITLE
avoid double serialization of discriminator value

### DIFF
--- a/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jackson1/JacksonDiscriminatorInheritanceTypeExtension.java
+++ b/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jackson1/JacksonDiscriminatorInheritanceTypeExtension.java
@@ -46,7 +46,7 @@ public class JacksonDiscriminatorInheritanceTypeExtension extends ObjectTypeHand
 
       typeSpec.addAnnotation(AnnotationSpec.builder(JsonTypeInfo.class)
               .addMember("use", "$T.Id.NAME", JsonTypeInfo.class)
-              .addMember("include", "$T.As.PROPERTY", JsonTypeInfo.class)
+              .addMember("include", "$T.As.EXISTING_PROPERTY", JsonTypeInfo.class)
               .addMember("property", "$S", otr.discriminator()).build());
 
       AnnotationSpec.Builder subTypes = AnnotationSpec.builder(JsonSubTypes.class);

--- a/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jackson2/JacksonDiscriminatorInheritanceTypeExtension.java
+++ b/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jackson2/JacksonDiscriminatorInheritanceTypeExtension.java
@@ -46,7 +46,7 @@ public class JacksonDiscriminatorInheritanceTypeExtension extends ObjectTypeHand
 
       typeSpec.addAnnotation(AnnotationSpec.builder(JsonTypeInfo.class)
               .addMember("use", "$T.Id.NAME", JsonTypeInfo.class)
-              .addMember("include", "$T.As.PROPERTY", JsonTypeInfo.class)
+              .addMember("include", "$T.As.EXISTING_PROPERTY", JsonTypeInfo.class)
               .addMember("property", "$S", otr.discriminator()).build());
 
       AnnotationSpec.Builder subTypes = AnnotationSpec.builder(JsonSubTypes.class);


### PR DESCRIPTION
In jackson, the generated classes containing a double property, if the super-type is annotated with As.PROPERTY. I changed this to As.EXISTING_PROPERTY