### PR TITLE
Plugin for covariant return types from https://github.com/mulesoft-labs/raml-for-jax-rs/issues/388

### DIFF
--- a/raml-to-pojo-maven-example/src/main/resources/api.raml
+++ b/raml-to-pojo-maven-example/src/main/resources/api.raml
@@ -122,21 +122,28 @@ types:
           - name: core.jackson2
       type: Ocean | Jungle
 
-#    listElementParent:
-#      type: object
-#      properties:
-#        name: string
-#
-#    listElementChild:
-#      type: listElementParent
-#      properties:
-#        name: string
-#
-#    listHolderParent:
-#      type: object
-#      properties:
-#        elements: listElementParent[]
-#    listHolderChild:
-#      type: listHolderParent
-#      properties:
-#        elements: listElementChild[]
+    listElementParent:
+      type: object
+      properties:
+        name: string
+
+    listElementChild:
+      type: listElementParent
+      properties:
+        name: string
+
+    listHolderParent:
+      type: object
+      (ramltopojo.types):
+        plugins:
+          - name: core.wildcardcollection
+            arguments: [java.lang.Object]
+      properties:
+        elements: listElementParent[]
+        names: string[]
+        id: integer
+
+    listHolderChild:
+      type: listHolderParent
+      properties:
+        elements: listElementChild[]

--- a/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/tools/CovariantListPlugin.java
+++ b/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/tools/CovariantListPlugin.java
@@ -1,0 +1,87 @@
+package org.raml.ramltopojo.extensions.tools;
+
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.WildcardTypeName;
+import org.raml.ramltopojo.EventType;
+import org.raml.ramltopojo.extensions.ObjectPluginContext;
+import org.raml.ramltopojo.extensions.ObjectTypeHandlerPlugin;
+import org.raml.v2.api.model.v10.datamodel.ArrayTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.ObjectTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.TypeDeclaration;
+
+import java.util.List;
+
+/**
+ * Created. There, you have it.
+ */
+public class CovariantListPlugin extends ObjectTypeHandlerPlugin.Helper {
+
+    private final List<String> arguments;
+
+    public CovariantListPlugin(List<String> arguments) {
+        this.arguments = arguments;
+    }
+
+    @Override
+    public MethodSpec.Builder getterBuilt(ObjectPluginContext objectPluginContext, TypeDeclaration declaration, MethodSpec.Builder incoming, EventType eventType) {
+
+        if ( eventType == EventType.INTERFACE) {
+
+            if (isNotTargetDefaultType(objectPluginContext, declaration, arguments)) return incoming;
+
+                if ( arguments.size() == 1 ) {
+
+                    // override.....
+                    incoming.returns(
+                            ParameterizedTypeName.get(
+                                    ClassName.get(List.class), WildcardTypeName.subtypeOf(ClassName.bestGuess(arguments.get(0)))));
+                    return incoming;
+                }
+
+            MethodSpec build = incoming.build();
+            ParameterizedTypeName type = (ParameterizedTypeName) build.returnType;
+
+            incoming.returns(ParameterizedTypeName.get(type.rawType, WildcardTypeName.subtypeOf(type.typeArguments.get(0))));
+        }
+
+        return incoming;
+    }
+
+    @Override
+    public MethodSpec.Builder setterBuilt(ObjectPluginContext objectPluginContext, TypeDeclaration declaration, MethodSpec.Builder incoming, EventType eventType) {
+
+        if ( eventType == EventType.INTERFACE) {
+
+            if ( arguments.size() == 1 ) {
+                return null;
+            }
+
+            if (isNotTargetDefaultType(objectPluginContext, declaration, arguments)) {
+                return incoming;
+            } else {
+
+                return null;
+            }
+        } else {
+
+            return incoming;
+        }
+    }
+
+    private  boolean isNotTargetDefaultType(ObjectPluginContext objectPluginContext, TypeDeclaration declaration, List<String> arguments) {
+        if (!(declaration instanceof ArrayTypeDeclaration)) {
+
+            return true;
+        }
+
+        ArrayTypeDeclaration arrayTypeDeclaration = (ArrayTypeDeclaration) declaration;
+        TypeDeclaration itemTypes = arrayTypeDeclaration.items();
+        if (!(itemTypes instanceof ObjectTypeDeclaration)) {
+
+            return true;
+        }
+        return arguments.size() == 0 && objectPluginContext.childClasses(itemTypes.name()).isEmpty();
+    }
+}

--- a/raml-to-pojo/src/main/resources/META-INF/ramltopojo-plugin.properties
+++ b/raml-to-pojo/src/main/resources/META-INF/ramltopojo-plugin.properties
@@ -44,3 +44,4 @@ core.asArray=org.raml.ramltopojo.extensions.tools.AsArray
 core.box=org.raml.ramltopojo.extensions.tools.BoxType
 core.boxWhenNotRequired=org.raml.ramltopojo.extensions.tools.BoxWhenNotRequired
 core.suppressType=org.raml.ramltopojo.extensions.tools.SuppressTypePlugin
+core.wildcardcollection=org.raml.ramltopojo.extensions.tools.CovariantListPlugin


### PR DESCRIPTION
Allow for using wildcard types for collections.  Made a plugin because I don't want to break anything 
as I'm removing a setter.