### PR TITLE
Fix for #39 (Nil union values not handled properly by jackson)

### DIFF
--- a/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/AllTypesPluginHelper.java
+++ b/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/AllTypesPluginHelper.java
@@ -70,6 +70,11 @@ public class AllTypesPluginHelper implements ObjectTypeHandlerPlugin, UnionTypeH
     }
 
     @Override
+    public FieldSpec.Builder fieldBuilt(UnionPluginContext unionPluginContext, TypeDeclaration ramlType, FieldSpec.Builder fieldSpec, EventType eventType) {
+    	return unionTypeHandlerPlugin.fieldBuilt(unionPluginContext, ramlType, fieldSpec, eventType);
+    }
+
+    @Override
     public FieldSpec.Builder anyFieldCreated(UnionPluginContext context, UnionTypeDeclaration union, TypeSpec.Builder typeSpec, FieldSpec.Builder anyType, EventType eventType) {
         return unionTypeHandlerPlugin.anyFieldCreated(context, union, typeSpec, anyType, eventType);
     }

--- a/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/UnionPluginContext.java
+++ b/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/UnionPluginContext.java
@@ -3,6 +3,7 @@ package org.raml.ramltopojo.extensions;
 import org.raml.ramltopojo.CreationResult;
 import org.raml.v2.api.model.v10.datamodel.TypeDeclaration;
 
+import com.squareup.javapoet.TypeName;
 /**
  * Created. There, you have it.
  */
@@ -10,4 +11,5 @@ public interface UnionPluginContext {
 
     CreationResult creationResult();
     CreationResult unionClass(TypeDeclaration ramlType);
+    TypeName findType(String typeName, TypeDeclaration type);
 }

--- a/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/UnionPluginContextImpl.java
+++ b/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/UnionPluginContextImpl.java
@@ -1,9 +1,12 @@
 package org.raml.ramltopojo.extensions;
 
 import org.raml.ramltopojo.CreationResult;
+import org.raml.ramltopojo.EventType;
 import org.raml.ramltopojo.GenerationContext;
+import org.raml.ramltopojo.TypeDeclarationType;
 import org.raml.v2.api.model.v10.datamodel.TypeDeclaration;
 
+import com.squareup.javapoet.TypeName;
 
 /**
  * Created. There, you have it.
@@ -21,6 +24,12 @@ public class UnionPluginContextImpl implements UnionPluginContext {
     public CreationResult creationResult() {
 
         return result;
+    }
+
+    @Override
+    public TypeName findType(String typeName, TypeDeclaration type) {
+
+        return TypeDeclarationType.calculateTypeName(typeName, type, generationContext, EventType.INTERFACE);
     }
 
     @Override

--- a/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/UnionTypeHandlerPlugin.java
+++ b/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/UnionTypeHandlerPlugin.java
@@ -4,6 +4,7 @@ import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.TypeSpec;
 import org.raml.ramltopojo.EventType;
+import org.raml.v2.api.model.v10.datamodel.TypeDeclaration;
 import org.raml.v2.api.model.v10.datamodel.UnionTypeDeclaration;
 
 import java.util.ArrayList;
@@ -32,11 +33,17 @@ public interface UnionTypeHandlerPlugin {
         public FieldSpec.Builder anyFieldCreated(UnionPluginContext context, UnionTypeDeclaration union, TypeSpec.Builder typeSpec, FieldSpec.Builder anyType, EventType eventType) {
             return anyType;
         }
+
+        @Override
+        public FieldSpec.Builder fieldBuilt(UnionPluginContext context, TypeDeclaration ramlType, FieldSpec.Builder fieldSpec, EventType eventType) {
+            return fieldSpec;
+        }
     }
 
     ClassName className(UnionPluginContext unionPluginContext, UnionTypeDeclaration ramlType, ClassName currentSuggestion, EventType eventType);
     TypeSpec.Builder classCreated(UnionPluginContext unionPluginContext, UnionTypeDeclaration ramlType, TypeSpec.Builder incoming, EventType eventType);
     FieldSpec.Builder anyFieldCreated(UnionPluginContext context, UnionTypeDeclaration union, TypeSpec.Builder typeSpec, FieldSpec.Builder anyType, EventType eventType);
+    FieldSpec.Builder fieldBuilt(UnionPluginContext unionPluginContext, TypeDeclaration ramlType, FieldSpec.Builder fieldSpec, EventType eventType);
 
     class Composite implements UnionTypeHandlerPlugin {
 
@@ -79,6 +86,17 @@ public interface UnionTypeHandlerPlugin {
             }
 
             return anyType;
+        }
+
+        @Override
+        public FieldSpec.Builder fieldBuilt(UnionPluginContext context, TypeDeclaration ramlType, FieldSpec.Builder fieldSpec, EventType eventType) {
+            for (UnionTypeHandlerPlugin plugin : plugins) {
+                if (fieldSpec == null) {
+                    break;
+                }
+                fieldSpec = plugin.fieldBuilt(context, ramlType, fieldSpec, eventType);
+            }
+            return fieldSpec;
         }
     }
 }

--- a/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jackson1/JacksonUnionExtension.java
+++ b/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jackson1/JacksonUnionExtension.java
@@ -2,9 +2,11 @@ package org.raml.ramltopojo.extensions.jackson1;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.squareup.javapoet.*;
 import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.JsonProcessingException;
 import org.codehaus.jackson.map.DeserializationContext;
@@ -14,20 +16,47 @@ import org.codehaus.jackson.map.annotate.JsonDeserialize;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.codehaus.jackson.map.deser.std.StdDeserializer;
 import org.codehaus.jackson.map.ser.std.SerializerBase;
+import org.codehaus.jackson.map.util.StdDateFormat;
 import org.raml.ramltopojo.EventType;
+import org.raml.ramltopojo.GenerationException;
 import org.raml.ramltopojo.Names;
+import org.raml.ramltopojo.Utils;
 import org.raml.ramltopojo.extensions.UnionPluginContext;
 import org.raml.ramltopojo.extensions.UnionTypeHandlerPlugin;
+import org.raml.v2.api.model.v10.datamodel.AnyTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.ArrayTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.BooleanTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.DateTimeOnlyTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.DateTimeTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.DateTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.FileTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.IntegerTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.NullTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.NumberTypeDeclaration;
 import org.raml.v2.api.model.v10.datamodel.ObjectTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.StringTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.TimeOnlyTypeDeclaration;
 import org.raml.v2.api.model.v10.datamodel.TypeDeclaration;
 import org.raml.v2.api.model.v10.datamodel.UnionTypeDeclaration;
 
 import javax.annotation.Nullable;
 import javax.lang.model.element.Modifier;
 import java.io.IOException;
+import java.sql.Date;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Created. There, you have it.
@@ -50,7 +79,7 @@ public class JacksonUnionExtension extends UnionTypeHandlerPlugin.Helper {
                 ClassName.get("", unionPluginContext.creationResult().getJavaName(EventType.INTERFACE).simpleName(),
                         Names.typeName("serializer"));
 
-        createSerializer(serializer, ramlType, incoming, eventType);
+        createSerializer(unionPluginContext, serializer, ramlType, incoming, eventType);
         createDeserializer(unionPluginContext, deserializer, ramlType, incoming, eventType);
 
         incoming.addAnnotation(AnnotationSpec.builder(JsonDeserialize.class)
@@ -61,22 +90,29 @@ public class JacksonUnionExtension extends UnionTypeHandlerPlugin.Helper {
         return incoming;
     }
 
-    private void createSerializer(ClassName serializerName, UnionTypeDeclaration union, TypeSpec.Builder typeBuilder, EventType eventType) {
+    private void createSerializer(UnionPluginContext unionPluginContext, ClassName serializerName, UnionTypeDeclaration union, TypeSpec.Builder typeBuilder, EventType eventType) {
 
         if ( eventType == EventType.IMPLEMENTATION) {
             return;
+        }
+
+        // check if union is ambiguous (duplicate primitive types)
+        if (isAmbiguousUnion(union.of())) {
+            throw new GenerationException(
+                "This union is ambiguous. It's impossible to create a Jackson-Serialization/-Deserialization strategy for ambiguous types: "
+                    + union.of().stream().map(x -> prettyName(x, unionPluginContext)).collect(Collectors.toList())
+                    + ". Use unique primitive types or classes with discriminator to solve this conflict."
+            );
         }
 
         ClassName typeBuilderName = ClassName.get("", typeBuilder.build().name);
         TypeSpec.Builder builder = TypeSpec.classBuilder(serializerName)
                 .addModifiers(Modifier.STATIC, Modifier.PUBLIC)
                 .superclass(ParameterizedTypeName.get(ClassName.get(SerializerBase.class), typeBuilderName))
-                .addMethod(
-                        MethodSpec.constructorBuilder()
-                                .addModifiers(Modifier.PUBLIC)
-                                .addCode("super($T.class);", typeBuilderName).build()
-
-                ).addModifiers(Modifier.PUBLIC);
+                .addMethod(MethodSpec.constructorBuilder()
+                    .addModifiers(Modifier.PUBLIC)
+                    .addStatement("super($T.class)", typeBuilderName)
+                    .build());
         MethodSpec.Builder serialize = MethodSpec.methodBuilder("serialize")
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(ParameterSpec.builder(typeBuilderName, "object").build())
@@ -87,8 +123,11 @@ public class JacksonUnionExtension extends UnionTypeHandlerPlugin.Helper {
 
         for (TypeDeclaration typeDeclaration : union.of()) {
 
-            String isMethod = Names.methodName("is", typeDeclaration.name());
-            String getMethod = Names.methodName("get", typeDeclaration.name());
+            // use defined type name or primitives names
+            String name = prettyName(typeDeclaration, unionPluginContext);
+
+            String isMethod = Names.methodName("is", name);
+            String getMethod = Names.methodName("get", name);
             serialize.beginControlFlow("if ( object." + isMethod + "())");
             serialize.addStatement("jsonGenerator.writeObject(object." + getMethod + "())");
             serialize.addStatement("return");
@@ -127,51 +166,242 @@ public class JacksonUnionExtension extends UnionTypeHandlerPlugin.Helper {
                 .addException(JsonProcessingException.class)
                 .returns(typeBuilderName)
                 .addStatement("$T mapper  = new $T()", ObjectMapper.class, ObjectMapper.class)
-                .addStatement("$T<String, Object> map = mapper.readValue(jsonParser, Map.class)", Map.class);
+                .addStatement("$T node = mapper.readTree(jsonParser)", JsonNode.class);
 
+        boolean dateValidation = false;
+        boolean objectValidation = false;
 
-        for (TypeDeclaration typeDeclaration : union.of()) {
+        // we need to sort types for best deserialization results (int before number,
+        // date before string, ...)
+        List<TypeDeclaration> sortedTypes = new LinkedList<TypeDeclaration>(union.of());
+        Map<Class<? extends TypeDeclaration>, Integer> typePriority = getPriorityTypeMap();
+        Collections.sort(sortedTypes,(t1, t2) -> {
+                // if both types are objects, we first do discriminator objects
+                if (t1 instanceof ObjectTypeDeclaration && t2 instanceof ObjectTypeDeclaration) {
+                    String d1 = ((ObjectTypeDeclaration) t1).discriminator();
+                    String d2 = ((ObjectTypeDeclaration) t2).discriminator();
+                    return d1 != null && d2 != null ? 0 : (d2 == null ? -1 : (d1 == null ? 1 : 0));
+                }
+                // no furhter process needed for other types
+                return Integer.compare(typePriority.get(Utils.declarationType(t1)), typePriority.get(Utils.declarationType(t2)));
+            }
+        );
 
-            TypeName unionPossibility = unionPluginContext.unionClass(typeDeclaration).getJavaName(EventType.IMPLEMENTATION);
+        for (TypeDeclaration typeDeclaration : sortedTypes) {
 
-            String name = Names.methodName("looksLike", typeDeclaration.name());
-            deserialize.addStatement("if ( " + name + "(map) ) return new $T(mapper.convertValue(map, $T.class))",
-                    unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), unionPossibility);
+            // get type name of declaration
+            TypeName typeName = unionPluginContext.findType(typeDeclaration.name(), typeDeclaration).box();
 
-            buildLooksLike(builder, typeDeclaration);
+            if (typeDeclaration instanceof NullTypeDeclaration) {
+
+                deserialize.beginControlFlow("if (node.isNull())");
+                deserialize.addStatement("return new $T(null)", unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION));
+                deserialize.endControlFlow();
+
+            } else if (typeDeclaration instanceof BooleanTypeDeclaration) {
+
+                deserialize.beginControlFlow("if (node.isBoolean())");
+                deserialize.addStatement("return new $T(node.asBoolean())", unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION));
+                deserialize.endControlFlow();
+
+            } else if (typeDeclaration instanceof IntegerTypeDeclaration) {
+
+                deserialize.beginControlFlow("if (node.isInt())");
+                deserialize.addStatement("return new $T(node.asInt())", unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION));
+                deserialize.endControlFlow();
+
+            } else if (typeDeclaration instanceof StringTypeDeclaration) {
+
+                deserialize.beginControlFlow("if (node.isTextual())");
+                deserialize.addStatement("return new $T(node.asText())", unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION));
+                deserialize.endControlFlow();
+
+            } else if (typeDeclaration instanceof NumberTypeDeclaration) {
+
+                deserialize.beginControlFlow("if (node.isNumber())");
+                deserialize.addStatement("return new $T(mapper.treeToValue(node, $T.class))",
+                    unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), Number.class);
+                deserialize.endControlFlow();
+
+            } else if (typeDeclaration instanceof DateTypeDeclaration) {
+
+                dateValidation = true;
+
+                deserialize.beginControlFlow("if (node.isTextual() && isValidDate(node.asText(), $T.getDateInstance()))", StdDateFormat.class);
+                deserialize.addStatement("mapper.setDateFormat($T.getDateInstance())", StdDateFormat.class);
+                deserialize.addStatement("return new $T(mapper.treeToValue(node, $T.class))",
+                    unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), Date.class);
+                deserialize.endControlFlow();
+
+            } else if (typeDeclaration instanceof TimeOnlyTypeDeclaration) {
+
+                dateValidation = true;
+
+                deserialize.beginControlFlow("if (node.isTextual() && isValidDate(node.asText(), $T.getTimeInstance()))", StdDateFormat.class);
+                deserialize.addStatement("mapper.setDateFormat($T.getTimeInstance())", StdDateFormat.class);
+                deserialize.addStatement("return new $T(mapper.treeToValue(node, $T.class))",
+                    unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), Date.class);
+                deserialize.endControlFlow();
+
+            } else if (typeDeclaration instanceof DateTimeOnlyTypeDeclaration) {
+
+                dateValidation = true;
+
+                deserialize.beginControlFlow("if (node.isTextual() && isValidDate(node.asText(), $T.getDateTimeInstance()))", StdDateFormat.class);
+                deserialize.addStatement("mapper.setDateFormat($T.getDateTimeInstance())", StdDateFormat.class);
+                deserialize.addStatement("return new $T(mapper.treeToValue(node, $T.class))",
+                    unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION),Date.class);
+                deserialize.endControlFlow();
+
+            } else if (typeDeclaration instanceof DateTimeTypeDeclaration) {
+
+                dateValidation = true;
+
+                if (Objects.equals("rfc2616", ((DateTimeTypeDeclaration) typeDeclaration).format())) {
+                    deserialize.beginControlFlow("if (node.isTextual() && isValidDate(node.asText()), new $T($S)))",
+                        SimpleDateFormat.class, "EEE, dd MMM yyyy HH:mm:ss z");
+                    deserialize.addStatement("mapper.setDateFormat(new $T($S))", SimpleDateFormat.class, "EEE, dd MMM yyyy HH:mm:ss z");
+                    deserialize.addStatement("return new $T(mapper.treeToValue(node, $T.class))",
+                        unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), Date.class);
+                    deserialize.endControlFlow();
+                } else {
+                    deserialize.beginControlFlow("if (node.isTextual() && isValidDate(node.asText()), $T.getDateTimeInstance()))", StdDateFormat.class);
+                    deserialize.addStatement("mapper.setDateFormat($T.getDateTimeInstance())", StdDateFormat.class);
+                    deserialize.addStatement("return new $T(mapper.treeToValue(node, $T.class))",
+                        unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), Date.class);
+                    deserialize.endControlFlow();
+                }
+
+            } else if (typeDeclaration instanceof ArrayTypeDeclaration) {
+
+                ArrayTypeDeclaration arrayTypeDeclaration = (ArrayTypeDeclaration) typeDeclaration;
+                TypeName arrayType = unionPluginContext.findType(arrayTypeDeclaration.name(), arrayTypeDeclaration).box();
+
+                deserialize.beginControlFlow("if (node.isArray())");
+                deserialize.addStatement("return new $T(mapper.treeToValue(node, $T[].class))",
+                    unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), arrayType);
+                deserialize.endControlFlow();
+
+            } else if (typeDeclaration instanceof ObjectTypeDeclaration) {
+
+                objectValidation = true;
+                ObjectTypeDeclaration otd = (ObjectTypeDeclaration) typeDeclaration;
+
+                List<String> names = Lists.transform(otd.properties(), new Function<TypeDeclaration, String>() {
+                    @Nullable
+                    @Override
+                    public String apply(@Nullable TypeDeclaration input) {
+                        return "\"" + input.name() + "\"";
+                    }
+                });
+
+                deserialize.beginControlFlow("if (node.isObject() && isValidObject(node, $T.asList($L)))", Arrays.class, Joiner.on(",").join(names));
+                deserialize.addStatement("return new $T(mapper.treeToValue(node, $T.class))",
+                    unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), typeName);
+                deserialize.endControlFlow();
+
+            } else if (typeDeclaration instanceof AnyTypeDeclaration) {
+
+                throw new GenerationException("Type 'any' within a union is not supported yet");
+
+            } else if (typeDeclaration instanceof UnionTypeDeclaration) {
+
+                throw new GenerationException("Type 'union' within a union is not supported yet");
+
+            } else if (typeDeclaration instanceof FileTypeDeclaration) {
+
+                throw new GenerationException("Type 'file' within a union is not supported yet");
+
+            } else {
+
+                throw new GenerationException("Type 'unkown' within a union is not supported yet");
+
+            }
         }
 
+        if (dateValidation) {
+            buildDateValidation(builder);
+        }
+        if (objectValidation) {
+            buildObjectValidation(builder);
+        }
 
-        deserialize.addStatement("throw new $T($S + map)", IOException.class, "Can't figure out type of object");
+        deserialize.addStatement("throw new $T($S + node)", IOException.class, "Can't figure out type of object ");
         builder.addMethod(deserialize.build());
 
         typeBuilder.addType(builder.build());
     }
 
-    private void buildLooksLike(TypeSpec.Builder builder, TypeDeclaration typeDeclaration) {
+    private Map<Class<? extends TypeDeclaration>, Integer> getPriorityTypeMap() {
+        return new ImmutableMap.Builder<Class<? extends TypeDeclaration>, Integer>().put(NullTypeDeclaration.class, 1)
+            .put(BooleanTypeDeclaration.class, 2)
+            .put(IntegerTypeDeclaration.class, 3)
+            .put(NumberTypeDeclaration.class, 4)
+            .put(DateTypeDeclaration.class, 5)
+            .put(TimeOnlyTypeDeclaration.class, 6)
+            .put(DateTimeOnlyTypeDeclaration.class, 7)
+            .put(DateTimeTypeDeclaration.class, 8)
+            .put(StringTypeDeclaration.class, 9)
+            .put(ObjectTypeDeclaration.class, 10)
+            .put(ArrayTypeDeclaration.class, 11)
+            .put(UnionTypeDeclaration.class, 12)
+            .put(FileTypeDeclaration.class, 13)
+            .put(AnyTypeDeclaration.class, 14)
+            .build();
+    }
 
-        String name = Names.methodName("looksLike", typeDeclaration.name());
+    private void buildDateValidation(TypeSpec.Builder builder) {
         MethodSpec.Builder spec =
-                MethodSpec.methodBuilder(name).addParameter(ParameterizedTypeName.get(ClassName.get(Map.class),
-                        ClassName.get(String.class),
-                        ClassName.get(Object.class)), "map");
-        if (typeDeclaration instanceof ObjectTypeDeclaration) {
-
-            ObjectTypeDeclaration otd = (ObjectTypeDeclaration) typeDeclaration;
-            List<String> names = Lists.transform(otd.properties(), new Function<TypeDeclaration, String>() {
-
-                @Nullable
-                @Override
-                public String apply(@Nullable TypeDeclaration input) {
-                    return "\"" + input.name() + "\"";
-                }
-            });
-
-            spec.addStatement("return map.keySet().containsAll($T.asList($L))", Arrays.class, Joiner.on(",").join(names));
-        }
-
+            MethodSpec.methodBuilder("isValidDate").addParameter(ClassName.get(String.class), "value").addParameter(ClassName.get(DateFormat.class), "format");
+        spec.addStatement("try { return format.parse(value) != null; } catch ($T e) { return false; }", ParseException.class);
         spec.addModifiers(Modifier.PRIVATE).returns(TypeName.BOOLEAN);
         builder.addMethod(spec.build());
+    }
+
+    private void buildObjectValidation(TypeSpec.Builder builder) {
+        MethodSpec.Builder spec =
+            MethodSpec.methodBuilder("isValidObject")
+                .addParameter(ClassName.get(JsonNode.class), "node")
+                .addParameter(ParameterizedTypeName.get(List.class, String.class), "keys");
+        spec.addStatement("$T<$T> list = new $T<>()", List.class, String.class, ArrayList.class);
+        spec.addStatement("$T<$T> fieldIterator = node.fieldNames()", Iterator.class, String.class);
+        spec.addStatement("while (fieldIterator.hasNext()) { list.add(fieldIterator.next()); }");
+        spec.addStatement("return list.containsAll(keys)");
+        spec.addModifiers(Modifier.PRIVATE).returns(TypeName.BOOLEAN);
+        builder.addMethod(spec.build());
+    }
+
+    private boolean isAmbiguousUnion(List<TypeDeclaration> typeDeclarations) {
+        Set<Class<? extends TypeDeclaration>> uniqueTypeSet = new HashSet<>();
+        for (TypeDeclaration typeDeclaration : typeDeclarations) {
+            boolean isUnique = uniqueTypeSet.add(typeDeclaration.getClass());
+            // we already have this type
+            if (!isUnique) {
+                // it's valid to have different object types
+                if (typeDeclaration instanceof ObjectTypeDeclaration) {
+                    continue;
+                }
+                // all primitive types are invalid => ambiguous
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String prettyName(TypeDeclaration type, UnionPluginContext unionPluginContext) {
+        if (type.type() == null) {
+            return type instanceof NullTypeDeclaration ? "nil" : shorten(unionPluginContext.findType(type.name(), type).box());
+        } else {
+            return type.name();
+        }
+    }
+
+    private String shorten(TypeName typeName) {
+        if (!(typeName instanceof ClassName)) {
+            throw new GenerationException(typeName + toString() + " cannot be shortened reasonably");
+        } else {
+            return ((ClassName) typeName).simpleName();
+        }
     }
 
 }

--- a/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jackson1/JacksonUnionExtension.java
+++ b/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jackson1/JacksonUnionExtension.java
@@ -206,9 +206,23 @@ public class JacksonUnionExtension extends UnionTypeHandlerPlugin.Helper {
 
             } else if (typeDeclaration instanceof IntegerTypeDeclaration) {
 
-                deserialize.beginControlFlow("if (node.isInt())");
-                deserialize.addStatement("return new $T(node.asInt())", unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION));
-                deserialize.endControlFlow();
+                if (typeName.box().equals(TypeName.LONG.box())) {
+                    deserialize.beginControlFlow("if (node.isLong())");
+                    deserialize.addStatement("return new $T(node.asLong())", unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION));
+                    deserialize.endControlFlow();
+                }
+
+                if (typeName.box().equals(TypeName.INT.box())) {
+                    deserialize.beginControlFlow("if (node.isInt())");
+                    deserialize.addStatement("return new $T(node.asInt())", unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION));
+                    deserialize.endControlFlow();
+                }
+
+                if (typeName.box().equals(TypeName.SHORT.box())) {
+                    deserialize.beginControlFlow("if (node.isShort())");
+                    deserialize.addStatement("return new $T(mapper.treeToValue(node, $T.class)", unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), typeName);
+                    deserialize.endControlFlow();
+                }
 
             } else if (typeDeclaration instanceof StringTypeDeclaration) {
 

--- a/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jackson2/JacksonUnionExtension.java
+++ b/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jackson2/JacksonUnionExtension.java
@@ -204,9 +204,23 @@ public class JacksonUnionExtension extends UnionTypeHandlerPlugin.Helper {
 
             } else if (typeDeclaration instanceof IntegerTypeDeclaration) {
 
-                deserialize.beginControlFlow("if (node.isInt())");
-                deserialize.addStatement("return new $T(node.asInt())", unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION));
-                deserialize.endControlFlow();
+                if (typeName.box().equals(TypeName.LONG.box())) {
+                    deserialize.beginControlFlow("if (node.isLong())");
+                    deserialize.addStatement("return new $T(node.asLong())", unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION));
+                    deserialize.endControlFlow();
+                }
+
+                if (typeName.box().equals(TypeName.INT.box())) {
+                    deserialize.beginControlFlow("if (node.isInt())");
+                    deserialize.addStatement("return new $T(node.asInt())", unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION));
+                    deserialize.endControlFlow();
+                }
+
+                if (typeName.box().equals(TypeName.SHORT.box())) {
+                    deserialize.beginControlFlow("if (node.isShort())");
+                    deserialize.addStatement("return new $T(mapper.treeToValue(node, $T.class)", unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), typeName);
+                    deserialize.endControlFlow();
+                }
 
             } else if (typeDeclaration instanceof StringTypeDeclaration) {
 

--- a/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jackson2/JacksonUnionExtension.java
+++ b/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jackson2/JacksonUnionExtension.java
@@ -4,31 +4,61 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.squareup.javapoet.*;
+
 import org.raml.ramltopojo.EventType;
+import org.raml.ramltopojo.GenerationException;
 import org.raml.ramltopojo.Names;
+import org.raml.ramltopojo.Utils;
 import org.raml.ramltopojo.extensions.UnionPluginContext;
 import org.raml.ramltopojo.extensions.UnionTypeHandlerPlugin;
+import org.raml.v2.api.model.v10.datamodel.AnyTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.ArrayTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.BooleanTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.DateTimeOnlyTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.DateTimeTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.DateTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.FileTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.IntegerTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.NullTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.NumberTypeDeclaration;
 import org.raml.v2.api.model.v10.datamodel.ObjectTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.StringTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.TimeOnlyTypeDeclaration;
 import org.raml.v2.api.model.v10.datamodel.TypeDeclaration;
 import org.raml.v2.api.model.v10.datamodel.UnionTypeDeclaration;
 
 import javax.annotation.Nullable;
 import javax.lang.model.element.Modifier;
 import java.io.IOException;
+import java.sql.Date;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Created. There, you have it.
@@ -43,42 +73,45 @@ public class JacksonUnionExtension extends UnionTypeHandlerPlugin.Helper {
     @Override
     public TypeSpec.Builder classCreated(UnionPluginContext unionPluginContext, UnionTypeDeclaration ramlType, TypeSpec.Builder incoming, EventType eventType) {
 
-        ClassName deserializer =
-                ClassName.get("", unionPluginContext.creationResult().getJavaName(EventType.INTERFACE).simpleName(),
-                        Names.typeName(ramlType.name(), "deserializer"));
+        ClassName deserializer = ClassName.get("", unionPluginContext.creationResult().getJavaName(EventType.INTERFACE).simpleName(), Names.typeName("deserializer"));
+        ClassName serializer = ClassName.get("", unionPluginContext.creationResult().getJavaName(EventType.INTERFACE).simpleName(), Names.typeName("serializer"));
 
-        ClassName serializer =
-                ClassName.get("", unionPluginContext.creationResult().getJavaName(EventType.INTERFACE).simpleName(),
-                        Names.typeName("serializer"));
-
-        createSerializer(serializer, ramlType, incoming, eventType);
+        createSerializer(unionPluginContext, serializer, ramlType, incoming, eventType);
         createDeserializer(unionPluginContext, deserializer, ramlType, incoming, eventType);
 
-        incoming.addAnnotation(AnnotationSpec.builder(JsonDeserialize.class)
-                .addMember("using", "$T.class", deserializer).build());
-        incoming.addAnnotation(AnnotationSpec.builder(JsonSerialize.class)
-                .addMember("using", "$T.class", serializer).build());
+        incoming.addAnnotation(AnnotationSpec.builder(JsonDeserialize.class).addMember("using", "$T.class", deserializer).build());
+        incoming.addAnnotation(AnnotationSpec.builder(JsonSerialize.class).addMember("using", "$T.class", serializer).build());
 
         return incoming;
     }
 
-    private void createSerializer(ClassName serializerName, UnionTypeDeclaration union, TypeSpec.Builder typeBuilder, EventType eventType) {
+    private void createSerializer(UnionPluginContext unionPluginContext, ClassName serializerName, UnionTypeDeclaration union, TypeSpec.Builder typeBuilder, EventType eventType) {
 
-        if ( eventType == EventType.IMPLEMENTATION) {
+        if (eventType == EventType.IMPLEMENTATION) {
             return;
         }
 
+        // check if union is ambiguous (duplicate primitive types)
+        if (isAmbiguousUnion(union.of())) {
+            throw new GenerationException(
+                "This union is ambiguous. It's impossible to create a Jackson-Serialization/-Deserialization strategy for ambiguous types: "
+                    + union.of().stream().map(x -> prettyName(x, unionPluginContext)).collect(Collectors.toList())
+                    + ". Use unique primitive types or classes with discriminator to solve this conflict."
+            );
+        }
+
         ClassName typeBuilderName = ClassName.get("", typeBuilder.build().name);
-        TypeSpec.Builder builder = TypeSpec.classBuilder(serializerName)
+        TypeSpec.Builder builder =
+            TypeSpec.classBuilder(serializerName)
                 .addModifiers(Modifier.STATIC, Modifier.PUBLIC)
                 .superclass(ParameterizedTypeName.get(ClassName.get(StdSerializer.class), typeBuilderName))
-                .addMethod(
-                        MethodSpec.constructorBuilder()
-                                .addModifiers(Modifier.PUBLIC)
-                                .addCode("super($T.class);", typeBuilderName).build()
-
-                ).addModifiers(Modifier.PUBLIC);
-        MethodSpec.Builder serialize = MethodSpec.methodBuilder("serialize")
+                .addMethod(MethodSpec.constructorBuilder()
+                    .addModifiers(Modifier.PUBLIC)
+                    .addStatement("super($T.class)", typeBuilderName)
+                    .build())
+                .addModifiers(Modifier.PUBLIC);
+        MethodSpec.Builder serialize =
+            MethodSpec.methodBuilder("serialize")
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(ParameterSpec.builder(typeBuilderName, "object").build())
                 .addParameter(ParameterSpec.builder(ClassName.get(JsonGenerator.class), "jsonGenerator").build())
@@ -88,8 +121,11 @@ public class JacksonUnionExtension extends UnionTypeHandlerPlugin.Helper {
 
         for (TypeDeclaration typeDeclaration : union.of()) {
 
-            String isMethod = Names.methodName("is", typeDeclaration.name());
-            String getMethod = Names.methodName("get", typeDeclaration.name());
+            // use defined type name or primitives names
+            String name = prettyName(typeDeclaration, unionPluginContext);
+
+            String isMethod = Names.methodName("is", name);
+            String getMethod = Names.methodName("get", name);
             serialize.beginControlFlow("if ( object." + isMethod + "())");
             serialize.addStatement("jsonGenerator.writeObject(object." + getMethod + "())");
             serialize.addStatement("return");
@@ -104,23 +140,23 @@ public class JacksonUnionExtension extends UnionTypeHandlerPlugin.Helper {
 
     private void createDeserializer(UnionPluginContext unionPluginContext, ClassName serializerName, UnionTypeDeclaration union, TypeSpec.Builder typeBuilder, EventType eventType) {
 
-        if ( eventType == EventType.IMPLEMENTATION) {
+        if (eventType == EventType.IMPLEMENTATION) {
             return;
         }
 
         ClassName typeBuilderName = ClassName.get("", typeBuilder.build().name);
 
-        TypeSpec.Builder builder = TypeSpec.classBuilder(serializerName)
+        TypeSpec.Builder builder =
+            TypeSpec.classBuilder(serializerName)
                 .addModifiers(Modifier.STATIC, Modifier.PUBLIC)
                 .superclass(ParameterizedTypeName.get(ClassName.get(StdDeserializer.class), typeBuilderName))
-                .addMethod(
-                        MethodSpec.constructorBuilder()
-                                .addModifiers(Modifier.PUBLIC)
-                                .addCode("super($T.class);", typeBuilderName).build()
-
-                ).addModifiers(Modifier.PUBLIC);
-
-        MethodSpec.Builder deserialize = MethodSpec.methodBuilder("deserialize")
+                .addMethod(MethodSpec.constructorBuilder()
+                    .addModifiers(Modifier.PUBLIC)
+                    .addStatement("super($T.class)", typeBuilderName)
+                    .build())
+                .addModifiers(Modifier.PUBLIC);
+        MethodSpec.Builder deserialize =
+            MethodSpec.methodBuilder("deserialize")
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(ParameterSpec.builder(ClassName.get(JsonParser.class), "jsonParser").build())
                 .addParameter(ParameterSpec.builder(ClassName.get(DeserializationContext.class), "jsonContext").build())
@@ -128,89 +164,264 @@ public class JacksonUnionExtension extends UnionTypeHandlerPlugin.Helper {
                 .addException(JsonProcessingException.class)
                 .returns(typeBuilderName)
                 .addStatement("$T mapper  = new $T()", ObjectMapper.class, ObjectMapper.class)
-                .addStatement("$T<String, Object> map = mapper.readValue(jsonParser, Map.class)", Map.class);
+                .addStatement("$T node = mapper.readTree(jsonParser)", JsonNode.class);
 
+        boolean dateValidation = false;
+        boolean objectValidation = false;
 
-        List<TypeDeclaration> unionOf = union.of();
-
-        for (TypeDeclaration typeDeclaration : unionOf) {
-
-
-            String name = Names.methodName("looksLike", typeDeclaration.name());
-            if ( typeDeclaration instanceof ObjectTypeDeclaration && ((ObjectTypeDeclaration)typeDeclaration).discriminator() != null ) {
-
-                TypeDeclaration parentType = findParentType(typeDeclaration);
-                TypeName unionPossibility = unionPluginContext.unionClass(typeDeclaration).getJavaName(EventType.INTERFACE);
-                ClassName javaName = unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION);
-                deserialize.addStatement("if ( " + name + "(map) ) return new $T(($T)mapper.convertValue(map, $T.class))",
-                        javaName,  unionPossibility,  unionPluginContext.unionClass(parentType).getJavaName(EventType.INTERFACE));
-            } else {
-                TypeName unionPossibility = unionPluginContext.unionClass(typeDeclaration).getJavaName(EventType.IMPLEMENTATION);
-                deserialize.addStatement("if ( " + name + "(map) ) return new $T(mapper.convertValue(map, $T.class))",
-                        unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), unionPossibility);
+        // we need to sort types for best deserialization results (int before number,
+        // date before string, ...)
+        List<TypeDeclaration> sortedTypes = new LinkedList<TypeDeclaration>(union.of());
+        Map<Class<? extends TypeDeclaration>, Integer> typePriority = getPriorityTypeMap();
+        Collections.sort(sortedTypes,(t1, t2) -> {
+                // if both types are objects, we first do discriminator objects
+                if (t1 instanceof ObjectTypeDeclaration && t2 instanceof ObjectTypeDeclaration) {
+                    String d1 = ((ObjectTypeDeclaration) t1).discriminator();
+                    String d2 = ((ObjectTypeDeclaration) t2).discriminator();
+                    return d1 != null && d2 != null ? 0 : (d2 == null ? -1 : (d1 == null ? 1 : 0));
+                }
+                // no furhter process needed for other types
+                return Integer.compare(typePriority.get(Utils.declarationType(t1)), typePriority.get(Utils.declarationType(t2)));
             }
+        );
 
-            buildLooksLike(builder, typeDeclaration);
+        for (TypeDeclaration typeDeclaration : sortedTypes) {
+
+            // get type name of declaration
+            TypeName typeName = unionPluginContext.findType(typeDeclaration.name(), typeDeclaration).box();
+
+            if (typeDeclaration instanceof NullTypeDeclaration) {
+
+                deserialize.beginControlFlow("if (node.isNull())");
+                deserialize.addStatement("return new $T(null)", unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION));
+                deserialize.endControlFlow();
+
+            } else if (typeDeclaration instanceof BooleanTypeDeclaration) {
+
+                deserialize.beginControlFlow("if (node.isBoolean())");
+                deserialize.addStatement("return new $T(node.asBoolean())", unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION));
+                deserialize.endControlFlow();
+
+            } else if (typeDeclaration instanceof IntegerTypeDeclaration) {
+
+                deserialize.beginControlFlow("if (node.isInt())");
+                deserialize.addStatement("return new $T(node.asInt())", unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION));
+                deserialize.endControlFlow();
+
+            } else if (typeDeclaration instanceof StringTypeDeclaration) {
+
+                deserialize.beginControlFlow("if (node.isTextual())");
+                deserialize.addStatement("return new $T(node.asText())", unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION));
+                deserialize.endControlFlow();
+
+            } else if (typeDeclaration instanceof NumberTypeDeclaration) {
+
+                deserialize.beginControlFlow("if (node.isNumber())");
+                deserialize.addStatement("return new $T(mapper.treeToValue(node, $T.class))",
+                    unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), Number.class);
+                deserialize.endControlFlow();
+
+            } else if (typeDeclaration instanceof DateTypeDeclaration) {
+
+                dateValidation = true;
+
+                deserialize.beginControlFlow("if (node.isTextual() && isValidDate(node.asText(), $T.getDateInstance()))", StdDateFormat.class);
+                deserialize.addStatement("mapper.setDateFormat($T.getDateInstance())", StdDateFormat.class);
+                deserialize.addStatement("return new $T(mapper.treeToValue(node, $T.class))",
+                    unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), Date.class);
+                deserialize.endControlFlow();
+
+            } else if (typeDeclaration instanceof TimeOnlyTypeDeclaration) {
+
+                dateValidation = true;
+
+                deserialize.beginControlFlow("if (node.isTextual() && isValidDate(node.asText(), $T.getTimeInstance()))", StdDateFormat.class);
+                deserialize.addStatement("mapper.setDateFormat($T.getTimeInstance())", StdDateFormat.class);
+                deserialize.addStatement("return new $T(mapper.treeToValue(node, $T.class))",
+                    unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), Date.class);
+                deserialize.endControlFlow();
+
+            } else if (typeDeclaration instanceof DateTimeOnlyTypeDeclaration) {
+
+                dateValidation = true;
+
+                deserialize.beginControlFlow("if (node.isTextual() && isValidDate(node.asText(), $T.getDateTimeInstance()))", StdDateFormat.class);
+                deserialize.addStatement("mapper.setDateFormat($T.getDateTimeInstance())", StdDateFormat.class);
+                deserialize.addStatement("return new $T(mapper.treeToValue(node, $T.class))",
+                    unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION),Date.class);
+                deserialize.endControlFlow();
+
+            } else if (typeDeclaration instanceof DateTimeTypeDeclaration) {
+
+                dateValidation = true;
+
+                if (Objects.equals("rfc2616", ((DateTimeTypeDeclaration) typeDeclaration).format())) {
+                    deserialize.beginControlFlow("if (node.isTextual() && isValidDate(node.asText()), new $T($S)))",
+                        SimpleDateFormat.class, "EEE, dd MMM yyyy HH:mm:ss z");
+                    deserialize.addStatement("mapper.setDateFormat(new $T($S))", SimpleDateFormat.class, "EEE, dd MMM yyyy HH:mm:ss z");
+                    deserialize.addStatement("return new $T(mapper.treeToValue(node, $T.class))",
+                        unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), Date.class);
+                    deserialize.endControlFlow();
+                } else {
+                    deserialize.beginControlFlow("if (node.isTextual() && isValidDate(node.asText()), $T.getDateTimeInstance()))", StdDateFormat.class);
+                    deserialize.addStatement("mapper.setDateFormat($T.getDateTimeInstance())", StdDateFormat.class);
+                    deserialize.addStatement("return new $T(mapper.treeToValue(node, $T.class))",
+                        unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), Date.class);
+                    deserialize.endControlFlow();
+                }
+
+            } else if (typeDeclaration instanceof ArrayTypeDeclaration) {
+
+                ArrayTypeDeclaration arrayTypeDeclaration = (ArrayTypeDeclaration) typeDeclaration;
+                TypeName arrayType = unionPluginContext.findType(arrayTypeDeclaration.name(), arrayTypeDeclaration).box();
+
+                deserialize.beginControlFlow("if (node.isArray())");
+                deserialize.addStatement("return new $T(mapper.treeToValue(node, $T[].class))",
+                    unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), arrayType);
+                deserialize.endControlFlow();
+
+            } else if (typeDeclaration instanceof ObjectTypeDeclaration) {
+
+                objectValidation = true;
+                ObjectTypeDeclaration otd = (ObjectTypeDeclaration) typeDeclaration;
+
+                List<String> names = Lists.transform(otd.properties(), new Function<TypeDeclaration, String>() {
+                    @Nullable
+                    @Override
+                    public String apply(@Nullable TypeDeclaration input) {
+                        return "\"" + input.name() + "\"";
+                    }
+                });
+
+                if (otd.discriminator() != null) {
+
+                    TypeName unionPossibility = unionPluginContext.unionClass(typeDeclaration).getJavaName(EventType.INTERFACE);
+
+                    deserialize.beginControlFlow("if (node.isObject() && isValidObject(node, $T.asList($L)) && $T.equals(node.path($S).asText(), $S))",
+                        Arrays.class, Joiner.on(",").join(names), Objects.class, otd.discriminator(), Optional.ofNullable(otd.discriminatorValue()).orElse(otd.name()));
+                    deserialize.addStatement("return new $T(($T)mapper.treeToValue(node, $T.class))",
+                        unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), unionPossibility, unionPluginContext.unionClass(findParentType(typeDeclaration)).getJavaName(EventType.INTERFACE));
+                    deserialize.endControlFlow();
+
+                } else {
+
+                    deserialize.beginControlFlow("if (node.isObject() && isValidObject(node, $T.asList($L)))", Arrays.class, Joiner.on(",").join(names));
+                    deserialize.addStatement("return new $T(mapper.treeToValue(node, $T.class))",
+                        unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), typeName);
+                    deserialize.endControlFlow();
+
+                }
+
+            } else if (typeDeclaration instanceof AnyTypeDeclaration) {
+
+                throw new GenerationException("Type 'any' within a union is not supported yet");
+
+            } else if (typeDeclaration instanceof UnionTypeDeclaration) {
+
+                throw new GenerationException("Type 'union' within a union is not supported yet");
+
+            } else if (typeDeclaration instanceof FileTypeDeclaration) {
+
+                throw new GenerationException("Type 'file' within a union is not supported yet");
+
+            } else {
+
+                throw new GenerationException("Type 'unkown' within a union is not supported yet");
+
+            }
         }
 
+        if (dateValidation) {
+            buildDateValidation(builder);
+        }
+        if (objectValidation) {
+            buildObjectValidation(builder);
+        }
 
-
-        deserialize.addStatement("throw new $T($S + map)", IOException.class, "Can't figure out type of object");
+        deserialize.addStatement("throw new $T($S + node)", IOException.class, "Can't figure out type of object ");
         builder.addMethod(deserialize.build());
 
         typeBuilder.addType(builder.build());
     }
 
+    private Map<Class<? extends TypeDeclaration>, Integer> getPriorityTypeMap() {
+        return new ImmutableMap.Builder<Class<? extends TypeDeclaration>, Integer>().put(NullTypeDeclaration.class, 1)
+            .put(BooleanTypeDeclaration.class, 2)
+            .put(IntegerTypeDeclaration.class, 3)
+            .put(NumberTypeDeclaration.class, 4)
+            .put(DateTypeDeclaration.class, 5)
+            .put(TimeOnlyTypeDeclaration.class, 6)
+            .put(DateTimeOnlyTypeDeclaration.class, 7)
+            .put(DateTimeTypeDeclaration.class, 8)
+            .put(StringTypeDeclaration.class, 9)
+            .put(ObjectTypeDeclaration.class, 10)
+            .put(ArrayTypeDeclaration.class, 11)
+            .put(UnionTypeDeclaration.class, 12)
+            .put(FileTypeDeclaration.class, 13)
+            .put(AnyTypeDeclaration.class, 14)
+            .build();
+    }
+
     private TypeDeclaration findParentType(TypeDeclaration typeDeclaration) {
-
-        if ( typeDeclaration instanceof ObjectTypeDeclaration ) {
+        if (typeDeclaration instanceof ObjectTypeDeclaration) {
             ObjectTypeDeclaration otd = (ObjectTypeDeclaration) typeDeclaration;
-            return otd.parentTypes().size() > 0 ?otd.parentTypes().get(0):otd;
+            return otd.parentTypes().size() > 0 ? otd.parentTypes().get(0) : otd;
         } else {
-
             return typeDeclaration;
         }
     }
 
-    private void buildLooksLike(TypeSpec.Builder builder, TypeDeclaration typeDeclaration) {
-
-        String name = Names.methodName("looksLike", typeDeclaration.name());
+    private void buildDateValidation(TypeSpec.Builder builder) {
         MethodSpec.Builder spec =
-                MethodSpec.methodBuilder(name).addParameter(ParameterizedTypeName.get(ClassName.get(Map.class),
-                        ClassName.get(String.class),
-                        ClassName.get(Object.class)), "map");
-        if (typeDeclaration instanceof ObjectTypeDeclaration) {
-
-            ObjectTypeDeclaration otd = (ObjectTypeDeclaration) typeDeclaration;
-            if ( otd.discriminator() != null ) {
-
-                List<String> names = Lists.transform(otd.properties(), new Function<TypeDeclaration, String>() {
-
-                    @Nullable
-                    @Override
-                    public String apply(@Nullable TypeDeclaration input) {
-                        return "\"" + input.name() + "\"";
-                    }
-                });
-
-                spec.addStatement("return map.keySet().containsAll($T.asList($L)) && map.get($S).equals($S)", Arrays.class, Joiner.on(",").join(names), otd.discriminator(), Optional.ofNullable(otd.discriminatorValue()).orElse(otd.name()));
-
-            } else {
-                List<String> names = Lists.transform(otd.properties(), new Function<TypeDeclaration, String>() {
-
-                    @Nullable
-                    @Override
-                    public String apply(@Nullable TypeDeclaration input) {
-                        return "\"" + input.name() + "\"";
-                    }
-                });
-
-                spec.addStatement("return map.keySet().containsAll($T.asList($L))", Arrays.class, Joiner.on(",").join(names));
-            }
-        }
-
+            MethodSpec.methodBuilder("isValidDate").addParameter(ClassName.get(String.class), "value").addParameter(ClassName.get(DateFormat.class), "format");
+        spec.addStatement("try { return format.parse(value) != null; } catch ($T e) { return false; }", ParseException.class);
         spec.addModifiers(Modifier.PRIVATE).returns(TypeName.BOOLEAN);
         builder.addMethod(spec.build());
     }
 
+    private void buildObjectValidation(TypeSpec.Builder builder) {
+        MethodSpec.Builder spec =
+            MethodSpec.methodBuilder("isValidObject")
+                .addParameter(ClassName.get(JsonNode.class), "node")
+                .addParameter(ParameterizedTypeName.get(List.class, String.class), "keys");
+        spec.addStatement("$T<$T> list = new $T<>()", List.class, String.class, ArrayList.class);
+        spec.addStatement("$T<$T> fieldIterator = node.fieldNames()", Iterator.class, String.class);
+        spec.addStatement("while (fieldIterator.hasNext()) { list.add(fieldIterator.next()); }");
+        spec.addStatement("return list.containsAll(keys)");
+        spec.addModifiers(Modifier.PRIVATE).returns(TypeName.BOOLEAN);
+        builder.addMethod(spec.build());
+    }
+
+    private boolean isAmbiguousUnion(List<TypeDeclaration> typeDeclarations) {
+        Set<Class<? extends TypeDeclaration>> uniqueTypeSet = new HashSet<>();
+        for (TypeDeclaration typeDeclaration : typeDeclarations) {
+            boolean isUnique = uniqueTypeSet.add(typeDeclaration.getClass());
+            // we already have this type
+            if (!isUnique) {
+                // it's valid to have different object types
+                if (typeDeclaration instanceof ObjectTypeDeclaration) {
+                    continue;
+                }
+                // all primitive types are invalid => ambiguous
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String prettyName(TypeDeclaration type, UnionPluginContext unionPluginContext) {
+        if (type.type() == null) {
+            return type instanceof NullTypeDeclaration ? "nil" : shorten(unionPluginContext.findType(type.name(), type).box());
+        } else {
+            return type.name();
+        }
+    }
+
+    private String shorten(TypeName typeName) {
+        if (!(typeName instanceof ClassName)) {
+            throw new GenerationException(typeName + toString() + " cannot be shortened reasonably");
+        } else {
+            return ((ClassName) typeName).simpleName();
+        }
+    }
 }

--- a/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jaxb/JaxbUnionExtension.java
+++ b/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jaxb/JaxbUnionExtension.java
@@ -67,4 +67,9 @@ public class JaxbUnionExtension implements UnionTypeHandlerPlugin {
 
         return anyType;
     }
+
+    @Override
+    public FieldSpec.Builder fieldBuilt(UnionPluginContext context, TypeDeclaration property, FieldSpec.Builder fieldSpec, EventType eventType) {
+        return fieldSpec;
+    }
 }

--- a/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jsr303/Jsr303Extension.java
+++ b/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jsr303/Jsr303Extension.java
@@ -28,50 +28,72 @@ import org.raml.v2.api.model.v10.datamodel.UnionTypeDeclaration;
 
 import static org.raml.ramltopojo.extensions.jsr303.FacetValidation.addAnnotations;
 
+import java.util.Objects;
+
+import javax.validation.constraints.NotNull;
+
 /**
  * Created by Jean-Philippe Belanger on 12/12/16. Just potential zeroes and ones
  */
 public class Jsr303Extension extends AllTypesPluginHelper {
 
-  @Override
-  public FieldSpec.Builder fieldBuilt(ObjectPluginContext objectPluginContext, TypeDeclaration typeDeclaration, FieldSpec.Builder fieldSpec, EventType eventType) {
-    AnnotationAdder adder = new AnnotationAdder() {
+    @Override
+    public FieldSpec.Builder fieldBuilt(ObjectPluginContext objectPluginContext, TypeDeclaration typeDeclaration, FieldSpec.Builder fieldSpec, EventType eventType) {
+        AnnotationAdder adder = new AnnotationAdder() {
 
-      @Override
-      public TypeName typeName() {
-        return fieldSpec.build().type;
-      }
+            @Override
+            public TypeName typeName() {
+                return fieldSpec.build().type;
+            }
 
-      @Override
-      public void addAnnotation(AnnotationSpec spec) {
-        fieldSpec.addAnnotation(spec);
-      }
-    };
+            @Override
+            public void addAnnotation(AnnotationSpec spec) {
+                fieldSpec.addAnnotation(spec);
+            }
+        };
 
+        addAnnotations(typeDeclaration, adder);
+        return fieldSpec;
+    }
 
-    addAnnotations(typeDeclaration, adder);
-    return fieldSpec;
-  }
+    @Override
+    public FieldSpec.Builder fieldBuilt(UnionPluginContext unionPluginContext, TypeDeclaration ramlType, FieldSpec.Builder fieldSpec, EventType eventType) {
+        AnnotationAdder adder = new AnnotationAdder() {
 
+            @Override
+            public TypeName typeName() {
+                return fieldSpec.build().type;
+            }
 
-  @Override
-  public FieldSpec.Builder anyFieldCreated(UnionPluginContext context, UnionTypeDeclaration union, TypeSpec.Builder typeSpec, FieldSpec.Builder anyType, EventType eventType) {
+            @Override
+            public void addAnnotation(AnnotationSpec spec) {
+                // ignore not null (we are in a union, of course they can be null)
+                if (!Objects.equals(spec.type, TypeName.get(NotNull.class))) {
+                    fieldSpec.addAnnotation(spec);
+                }
+            }
+        };
 
-    FacetValidation.addFacetsForBuilt(new AnnotationAdder() {
+        addAnnotations(ramlType, adder);
+        return fieldSpec;
+    }
 
-      @Override
-      public TypeName typeName() {
-        return anyType.build().type;
-      }
+    @Override
+    public FieldSpec.Builder anyFieldCreated( UnionPluginContext context, UnionTypeDeclaration union, TypeSpec.Builder typeSpec, FieldSpec.Builder anyType, EventType eventType) {
+        FacetValidation.addFacetsForBuilt(new AnnotationAdder() {
 
-      @Override
-      public void addAnnotation(AnnotationSpec spec) {
+            @Override
+            public TypeName typeName() {
+                return anyType.build().type;
+            }
 
-        anyType.addAnnotation(spec);
-      }
-    });
+            @Override
+            public void addAnnotation(AnnotationSpec spec) {
 
-    return anyType;
-  }
+                anyType.addAnnotation(spec);
+            }
+        });
 
+        return anyType;
+    }
 }

--- a/raml-to-pojo/src/test/java/org/raml/ramltopojo/extensions/jackson2/JacksonUnionExtensionTest.java
+++ b/raml-to-pojo/src/test/java/org/raml/ramltopojo/extensions/jackson2/JacksonUnionExtensionTest.java
@@ -1,93 +1,100 @@
 package org.raml.ramltopojo.extensions.jackson2;
 
+import static junit.framework.TestCase.assertNotNull;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.raml.testutils.matchers.MethodSpecMatchers.methodName;
+import static org.raml.testutils.matchers.TypeSpecMatchers.methods;
+import static org.raml.testutils.matchers.TypeSpecMatchers.innerTypes;
+import static org.raml.testutils.matchers.TypeSpecMatchers.name;
+import static org.raml.testutils.matchers.TypeSpecMatchers.annotations;
+import static org.raml.testutils.matchers.AnnotationSpecMatchers.annotationType;
+import static org.raml.testutils.matchers.AnnotationSpecMatchers.member;
+import static org.raml.testutils.matchers.CodeBlockMatchers.codeBlockContents;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.raml.ramltopojo.CreationResult;
+import org.raml.ramltopojo.EventType;
+import org.raml.ramltopojo.GenerationException;
+import org.raml.ramltopojo.RamlLoader;
+import org.raml.ramltopojo.RamlToPojo;
+import org.raml.ramltopojo.RamlToPojoBuilder;
+import org.raml.ramltopojo.TypeFetchers;
+import org.raml.ramltopojo.TypeFinders;
+import org.raml.v2.api.model.v10.api.Api;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.squareup.javapoet.ClassName;
+
 /**
  * Created. There, you have it.
  */
 public class JacksonUnionExtensionTest {
 
-/*
-    @Mock
-    private CurrentBuild build;
-
-    @Mock
-    private V10GType declaration;
-
-    @Mock
-    private UnionTypeDeclaration typeDeclaration;
-
-    @Mock
-    private TypeDeclaration unionOfType;
-
-    @Before
-    public void mockito() {
-
-        MockitoAnnotations.initMocks(this);
-    }
-
     @Test
-    public void makeIt() throws Exception {
+    public void complexInlineUnion() throws Exception {
 
-        when(declaration.name()).thenReturn("Foo");
-        when(declaration.implementation()).thenReturn(typeDeclaration);
-        when(build.getModelPackage()).thenReturn("model");
+        Api api = RamlLoader.load(this.getClass().getResourceAsStream("union-mix-type.raml"), ".");
+        RamlToPojo ramlToPojo = new RamlToPojoBuilder(api).fetchTypes(TypeFetchers.fromAnywhere()).findTypes(TypeFinders.everyWhere()).build(Arrays.asList("core.jackson2"));
+        CreationResult r = ramlToPojo.buildPojos().creationResults().stream().filter(x -> x.getJavaName(EventType.INTERFACE).simpleName().equals("Foo")).findFirst().get();
 
-        when(typeDeclaration.of()).thenReturn(Arrays.asList(unionOfType));
-        when(typeDeclaration.name()).thenReturn("Foo");
-        when(unionOfType.name()).thenReturn("UnionOf");
+        System.err.println(r.getInterface().toString());
+        System.err.println(r.getImplementation().get().toString());
 
-        UnionDeserializationGenerator generator = new UnionDeserializationGenerator(build, declaration,
-                ClassName.get("foo", "CooGenerator")) {
-
-            @Override
-            protected UnionTypeDeclaration getUnionTypeDeclaration() {
-                return typeDeclaration;
-            }
-        };
-
-        generator.output(new CodeContainer<TypeSpec.Builder>() {
-
-            @Override
-            public void into(TypeSpec.Builder g) throws IOException {
-
-                TypeName looksLikeType = ParameterizedTypeName.get(Map.class, String.class, Object.class);
-                TypeName jsonParser = ClassName.get(JsonParser.class);
-                TypeName context = ClassName.get(DeserializationContext.class);
-
-                assertThat(g.build(), TypeSpecMatchers.name(is(equalTo("CooGenerator"))));
-                assertThat(g.build(),
-                        TypeSpecMatchers.methods(containsInAnyOrder(
-                                allOf(
-                                        MethodSpecMatchers
-                                                .methodName(is(equalTo("looksLikeUnionOf"))),
-                                        MethodSpecMatchers.parameters(
-                                                contains(
-                                                        ParameterSpecMatchers.type(is(equalTo(looksLikeType)))
-                                                )
-                                        )
-                                ),
-                                allOf(
-                                        MethodSpecMatchers.methodName(is(equalTo("deserialize"))),
-                                        MethodSpecMatchers.parameters(
-                                                contains(
-                                                        ParameterSpecMatchers
-                                                                .type(is(equalTo(jsonParser))),
-                                                        ParameterSpecMatchers
-                                                                .type(is(equalTo(context)))
-                                                )
-                                        ),
-                                        MethodSpecMatchers
-                                                .codeContent(containsString("looksLikeUnionOf")) // approx
-                                ),
-                                allOf(
-                                        MethodSpecMatchers.methodName(is(equalTo("<init>")))
-                                )
-
-
-                        )));
-
-            }
-        });
+        assertNotNull(r);
+        assertThat(
+            r.internalType("prop").getInterface(),
+            is(
+                allOf(
+                    name(is(equalTo("BaaEmailBooleanIntegerNilUnion"))),
+                    annotations(
+                        containsInAnyOrder(
+                            allOf(
+                                annotationType(equalTo(ClassName.get(JsonSerialize.class))),
+                                member("using", contains(codeBlockContents(equalTo("BaaEmailBooleanIntegerNilUnion.Serializer.class"))))
+                            ),
+                            allOf(
+                                annotationType(equalTo(ClassName.get(JsonDeserialize.class))),
+                                member("using", contains(codeBlockContents(equalTo("BaaEmailBooleanIntegerNilUnion.Deserializer.class"))))
+                            )
+                        )
+                    ),
+                    innerTypes(
+                        contains(
+                            allOf(
+                                name(is(equalTo("Serializer"))),
+                                methods(contains(
+                                    allOf(methodName(equalTo("<init>"))),
+                                    allOf(methodName(equalTo("serialize")))
+                                ))
+                            ),
+                            allOf(
+                                name(is(equalTo("Deserializer"))),
+                                methods(containsInAnyOrder(
+                                    allOf(methodName(equalTo("<init>"))),
+                                    allOf(methodName(equalTo("isValidObject"))),
+                                    allOf(methodName(equalTo("deserialize")))
+                                ))
+                            ),
+                            allOf(name(is(equalTo("UnionType"))))
+                        )
+                    )
+                )
+            )
+        );
     }
-*/
 
+    @Test(expected = GenerationException.class)
+    public void ambiguousUnion() throws Exception {
+        Api api = RamlLoader.load(this.getClass().getResourceAsStream("union-ambiguous-type.raml"), ".");
+        RamlToPojo ramlToPojo = new RamlToPojoBuilder(api).fetchTypes(TypeFetchers.fromAnywhere()).findTypes(TypeFinders.everyWhere()).build(Arrays.asList("core.jackson2"));
+        ramlToPojo.buildPojos().creationResults();
+    }
 }

--- a/raml-to-pojo/src/test/java/org/raml/ramltopojo/extensions/jsr303/Jsr303UnionExtensionTest.java
+++ b/raml-to-pojo/src/test/java/org/raml/ramltopojo/extensions/jsr303/Jsr303UnionExtensionTest.java
@@ -1,0 +1,81 @@
+package org.raml.ramltopojo.extensions.jsr303;
+
+import static junit.framework.TestCase.assertNotNull;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.raml.testutils.matchers.AnnotationSpecMatchers.annotationType;
+import static org.raml.testutils.matchers.AnnotationSpecMatchers.member;
+import static org.raml.testutils.matchers.CodeBlockMatchers.codeBlockContents;
+import static org.raml.testutils.matchers.TypeSpecMatchers.fields;
+import static org.raml.testutils.matchers.TypeSpecMatchers.name;
+import static org.raml.testutils.matchers.FieldSpecMatchers.fieldName;
+import static org.raml.testutils.matchers.FieldSpecMatchers.fieldAnnotations;
+
+import java.util.Arrays;
+
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+import org.junit.Test;
+import org.raml.ramltopojo.CreationResult;
+import org.raml.ramltopojo.EventType;
+import org.raml.ramltopojo.RamlLoader;
+import org.raml.ramltopojo.RamlToPojo;
+import org.raml.ramltopojo.RamlToPojoBuilder;
+import org.raml.ramltopojo.TypeFetchers;
+import org.raml.ramltopojo.TypeFinders;
+import org.raml.v2.api.model.v10.api.Api;
+
+import com.squareup.javapoet.ClassName;
+
+public class Jsr303UnionExtensionTest {
+
+    @Test
+    public void unionValidation() throws Exception {
+
+        Api api = RamlLoader.load(this.getClass().getResourceAsStream("union-type.raml"), ".");
+        RamlToPojo ramlToPojo = new RamlToPojoBuilder(api).fetchTypes(TypeFetchers.fromAnywhere()).findTypes(TypeFinders.everyWhere()).build(Arrays.asList("core.jsr303"));
+        CreationResult r = ramlToPojo.buildPojos().creationResults().stream().filter(x -> x.getJavaName(EventType.INTERFACE).simpleName().equals("Foo")).findFirst().get();
+
+        System.err.println(r.getInterface().toString());
+        System.err.println(r.getImplementation().get().toString());
+
+        assertNotNull(r);
+        assertThat(
+            r.getImplementation().get(),
+            is(
+                allOf(
+                    name(
+                        is(equalTo("FooImpl"))
+                    ),
+                    fields(
+                        contains(
+                            allOf(fieldName(equalTo("unionType"))),
+                            allOf(
+                                fieldName(equalTo("emailValue")),
+                                fieldAnnotations(
+                                    allOf(
+                                        containsInAnyOrder(
+                                            allOf(
+                                                annotationType(equalTo(ClassName.get(Size.class))),
+                                                member("min", contains(codeBlockContents(equalTo("1"))))
+                                            ),
+                                            allOf(
+                                                annotationType(equalTo(ClassName.get(Pattern.class))),
+                                                member("regexp", contains(codeBlockContents(equalTo("\"^/.*$\""))))
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+}

--- a/raml-to-pojo/src/test/java/org/raml/ramltopojo/object/ObjectTypeHandlerTest.java
+++ b/raml-to-pojo/src/test/java/org/raml/ramltopojo/object/ObjectTypeHandlerTest.java
@@ -474,13 +474,14 @@ public class ObjectTypeHandlerTest extends UnitTest {
         assertThat(r.internalType("unionOfPrimitives").getInterface(), is(allOf(
 
                 name(
-                        is(equalTo("UnionOfPrimitivesType"))
+                        is(equalTo("StringIntegerUnion"))
                 ),
                 methods(containsInAnyOrder(
-                        allOf(methodName(equalTo("getInteger")), returnType(equalTo(ClassName.get(Integer.class)))),
-                        allOf(methodName(equalTo("isInteger")), returnType(equalTo(ClassName.get(Boolean.class).unbox()))),
+                        allOf(methodName(equalTo("getUnionType")), returnType(equalTo(ClassName.get("bar.pack", "Foo.StringIntegerUnion.UnionType")))),
+                        allOf(methodName(equalTo("isString")), returnType(equalTo(ClassName.get(Boolean.class).unbox()))),
                         allOf(methodName(equalTo("getString")), returnType(equalTo(ClassName.get(String.class)))),
-                        allOf(methodName(equalTo("isString")), returnType(equalTo(ClassName.get(Boolean.class).unbox())))
+                        allOf(methodName(equalTo("isInteger")), returnType(equalTo(ClassName.get(Boolean.class).unbox()))),
+                        allOf(methodName(equalTo("getInteger")), returnType(equalTo(ClassName.get(Integer.class))))
                 ))
 
         )));
@@ -488,13 +489,14 @@ public class ObjectTypeHandlerTest extends UnitTest {
         assertThat(r.internalType("unionOfOthers").getInterface(), is(allOf(
 
                 name(
-                        is(equalTo("UnionOfOthersType"))
+                        is(equalTo("OneTwoUnion"))
                 ),
                 methods(contains(
-                        allOf(methodName(equalTo("getOne")), returnType(equalTo(ClassName.get("pojo.pack", "One")))),
+                        allOf(methodName(equalTo("getUnionType")), returnType(equalTo(ClassName.get("bar.pack", "Foo.OneTwoUnion.UnionType")))),
                         allOf(methodName(equalTo("isOne")), returnType(equalTo(ClassName.get(Boolean.class).unbox()))),
-                        allOf(methodName(equalTo("getTwo")), returnType(equalTo(ClassName.get("pojo.pack", "Two")))),
-                        allOf(methodName(equalTo("isTwo")), returnType(equalTo(ClassName.get(Boolean.class).unbox())))
+                        allOf(methodName(equalTo("getOne")), returnType(equalTo(ClassName.get("pojo.pack", "One")))),
+                        allOf(methodName(equalTo("isTwo")), returnType(equalTo(ClassName.get(Boolean.class).unbox()))),
+                        allOf(methodName(equalTo("getTwo")), returnType(equalTo(ClassName.get("pojo.pack", "Two"))))
                 ))
 
         )));

--- a/raml-to-pojo/src/test/java/org/raml/ramltopojo/union/UnionTypeHandlerTest.java
+++ b/raml-to-pojo/src/test/java/org/raml/ramltopojo/union/UnionTypeHandlerTest.java
@@ -3,6 +3,7 @@ package org.raml.ramltopojo.union;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.squareup.javapoet.ClassName;
+
 import org.junit.Test;
 import org.raml.ramltopojo.CreationResult;
 import org.raml.ramltopojo.GenerationContextImpl;
@@ -14,6 +15,7 @@ import org.raml.v2.api.model.v10.datamodel.TypeDeclaration;
 import org.raml.v2.api.model.v10.datamodel.UnionTypeDeclaration;
 
 import javax.annotation.Nullable;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -31,52 +33,46 @@ import static org.raml.testutils.matchers.TypeSpecMatchers.*;
  * Created. There, you have it.
  */
 public class UnionTypeHandlerTest {
+
     @Test
     public void simpleUnion() throws Exception {
 
         Api api = RamlLoader.load(this.getClass().getResourceAsStream("union-type.raml"), ".");
         UnionTypeHandler handler = new UnionTypeHandler("foo", findTypes("foo", api.types()));
 
-        GenerationContextImpl generationContext = new GenerationContextImpl(PluginManager.NULL, api, TypeFetchers.fromTypes(), "bar.pack", Collections.<String>emptyList());
-        generationContext.newExpectedType("foo", new CreationResult("bar.pack", ClassName.get("bar.pack", "Foo"), ClassName.get("bar.pack", "FooImpl")));
-        CreationResult r = handler.create(generationContext, new CreationResult("bar.pack", ClassName.get("bar.pack", "Foo"), ClassName.get("bar.pack", "FooImpl"))).get();
+        GenerationContextImpl generationContext = new GenerationContextImpl(PluginManager.NULL, api,TypeFetchers.fromTypes(), "bar.pack", Collections.<String>emptyList());
+        generationContext.newExpectedType("foo",new CreationResult("bar.pack", ClassName.get("bar.pack", "Foo"), ClassName.get("bar.pack", "FooImpl")));
+        CreationResult r = handler.create(generationContext,new CreationResult("bar.pack", ClassName.get("bar.pack", "Foo"), ClassName.get("bar.pack", "FooImpl"))).get();
 
-
-        assertThat(r.getInterface(), is(allOf(
-                name(equalTo("Foo")),
-                methods(contains(
-                        allOf(methodName(equalTo("getFirst")), returnType(equalTo(ClassName.get("bar.pack", "First")))),
-                        allOf(methodName(equalTo("isFirst")), returnType(equalTo(ClassName.get(Boolean.class).unbox()))),
-                        allOf(methodName(equalTo("getSecond")), returnType(equalTo(ClassName.get("bar.pack", "Second")))),
-                        allOf(methodName(equalTo("isSecond")), returnType(equalTo(ClassName.get(Boolean.class).unbox())))
-                ))
-        )));
+        assertThat(r.getInterface(), is(allOf(name(equalTo("Foo")), methods(contains(
+            allOf(methodName(equalTo("getUnionType")), returnType(equalTo(ClassName.get("bar.pack", "Foo.UnionType")))),
+            allOf(methodName(equalTo("isFirst")), returnType(equalTo(ClassName.get(Boolean.class).unbox()))),
+            allOf(methodName(equalTo("getFirst")), returnType(equalTo(ClassName.get("bar.pack", "First")))),
+            allOf(methodName(equalTo("isSecond")), returnType(equalTo(ClassName.get(Boolean.class).unbox()))),
+            allOf(methodName(equalTo("getSecond")), returnType(equalTo(ClassName.get("bar.pack", "Second"))))
+        )))));
 
         System.err.println(r.getInterface().toString());
         System.err.println(r.getImplementation().toString());
 
-        assertThat(r.getImplementation().get(), is(allOf(
-                name(equalTo("FooImpl")),
-                fields(contains(
-                        allOf(fieldName(equalTo("anyType")), fieldType(equalTo(ClassName.get(Object.class))))
-                )),
-                methods(contains(
-                        allOf(methodName(equalTo("<init>"))),
-                        allOf(methodName(equalTo("<init>")), parameters(contains(type(equalTo(ClassName.get("bar.pack", "First")))))),
-                        allOf(methodName(equalTo("getFirst")), returnType(equalTo(ClassName.get("bar.pack", "First"))), codeContent(equalTo(
-                                "if ( !(anyType instanceof  bar.pack.First)) throw new java.lang.IllegalStateException(\"fetching wrong type out of the union: bar.pack.First\");\nreturn (bar.pack.First) anyType;\n"))),
-                        allOf(methodName(equalTo("isFirst")), returnType(equalTo(ClassName.get(Boolean.class).unbox())), codeContent(equalTo("return anyType instanceof bar.pack.First;\n"))),
-                        allOf(methodName(equalTo("<init>")), parameters(contains(type(equalTo(ClassName.get("bar.pack", "Second")))))),
-                        allOf(methodName(equalTo("getSecond")), returnType(equalTo(ClassName.get("bar.pack", "Second"))), codeContent(equalTo(
-                                "if ( !(anyType instanceof  bar.pack.Second)) throw new java.lang.IllegalStateException(\"fetching wrong type out of the union: bar.pack.Second\");\nreturn (bar.pack.Second) anyType;\n"))),
-                        allOf(methodName(equalTo("isSecond")), returnType(equalTo(ClassName.get(Boolean.class).unbox())), codeContent(equalTo("return anyType instanceof bar.pack.Second;\n")))
-                )),
-                superInterfaces(contains(
-                        allOf(typeName(equalTo(ClassName.get("bar.pack", "Foo"))))
-                ))
+        assertThat(r.getImplementation().get(), is(allOf(name(equalTo("FooImpl")),
+            fields(contains(
+                allOf(fieldName(equalTo("unionType")), fieldType(equalTo(ClassName.get("bar.pack", "Foo.UnionType")))),
+                allOf(fieldName(equalTo("firstValue")), fieldType(equalTo(ClassName.get("bar.pack", "First")))),
+                allOf(fieldName(equalTo("secondValue")), fieldType(equalTo(ClassName.get("bar.pack", "Second"))))
+            )),
+            methods(contains(allOf(methodName(equalTo("<init>"))),
+                allOf(methodName(equalTo("getUnionType")), returnType(equalTo(ClassName.get("bar.pack", "Foo.UnionType"))), codeContent(equalTo("return this.unionType;\n"))),
+                allOf(methodName(equalTo("<init>")),parameters(contains(type(equalTo(ClassName.get("bar.pack", "First")))))),
+                allOf(methodName(equalTo("isFirst")), returnType(equalTo(ClassName.get(Boolean.class).unbox())),codeContent(equalTo("return this.unionType == bar.pack.Foo.UnionType.FIRST;\n"))),
+                allOf(methodName(equalTo("getFirst")), returnType(equalTo(ClassName.get("bar.pack", "First"))),codeContent(equalTo("if (!isFirst()) throw new java.lang.IllegalStateException(\"fetching wrong type out of the union: bar.pack.First\");\nreturn this.firstValue;\n"))),
+                allOf(methodName(equalTo("<init>")),parameters(contains(type(equalTo(ClassName.get("bar.pack", "Second")))))),
+                allOf(methodName(equalTo("isSecond")),returnType(equalTo(ClassName.get(Boolean.class).unbox())),codeContent(equalTo("return this.unionType == bar.pack.Foo.UnionType.SECOND;\n"))),
+                allOf(methodName(equalTo("getSecond")),returnType(equalTo(ClassName.get("bar.pack", "Second"))),codeContent(equalTo("if (!isSecond()) throw new java.lang.IllegalStateException(\"fetching wrong type out of the union: bar.pack.Second\");\nreturn this.secondValue;\n")))
+            )),
+            superInterfaces(contains(allOf(typeName(equalTo(ClassName.get("bar.pack", "Foo"))))))
         )));
     }
-
 
     @Test
     public void primitiveUnion() throws Exception {
@@ -84,49 +80,39 @@ public class UnionTypeHandlerTest {
         Api api = RamlLoader.load(this.getClass().getResourceAsStream("union-primitive-type.raml"), ".");
         UnionTypeHandler handler = new UnionTypeHandler("foo", findTypes("foo", api.types()));
 
-        CreationResult r = handler.create(new GenerationContextImpl(PluginManager.NULL, api, TypeFetchers.fromTypes(), "bar.pack", Collections.<String>emptyList()), new CreationResult("bar.pack", ClassName.get("bar.pack", "Foo"), ClassName.get("bar.pack", "FooImpl"))).get();
+        CreationResult r = handler.create(new GenerationContextImpl(PluginManager.NULL, api, TypeFetchers.fromTypes(), "bar.pack",Collections.<String>emptyList()),new CreationResult("bar.pack", ClassName.get("bar.pack", "Foo"), ClassName.get("bar.pack", "FooImpl"))).get();
 
-        assertThat(r.getInterface(), is(allOf(
-                name(equalTo("Foo")),
-                methods(contains(
-                        allOf(methodName(equalTo("getInteger")), returnType(equalTo(ClassName.get(Integer.class)))),
-                        allOf(methodName(equalTo("isInteger")), returnType(equalTo(ClassName.get(Boolean.class).unbox()))),
-                        allOf(methodName(equalTo("getSecond")), returnType(equalTo(ClassName.get("", "bar.pack.Second")))),
-                        allOf(methodName(equalTo("isSecond")), returnType(equalTo(ClassName.get(Boolean.class).unbox())))
-                ))
-        )));
-
+        assertThat(r.getInterface(), is(allOf(name(equalTo("Foo")), methods(contains(
+            allOf(methodName(equalTo("getUnionType")), returnType(equalTo(ClassName.get("bar.pack", "Foo.UnionType")))),
+            allOf(methodName(equalTo("isInteger")), returnType(equalTo(ClassName.get(Boolean.class).unbox()))),
+            allOf(methodName(equalTo("getInteger")), returnType(equalTo(ClassName.get(Integer.class)))),
+            allOf(methodName(equalTo("isSecond")), returnType(equalTo(ClassName.get(Boolean.class).unbox()))),
+            allOf(methodName(equalTo("getSecond")), returnType(equalTo(ClassName.get("", "bar.pack.Second"))))
+        )))));
 
         System.err.println(r.getInterface().toString());
         System.err.println(r.getImplementation().toString());
 
-
-        assertThat(r.getImplementation().get(), is(allOf(
-                name(equalTo("FooImpl")),
-                fields(contains(
-                        allOf(fieldName(equalTo("anyType")), fieldType(equalTo(ClassName.get(Object.class))))
-                )),
-
-                methods(contains(
-                        methodName(equalTo("<init>")),
-                        allOf(methodName(equalTo("<init>")), parameters(contains(type(equalTo(ClassName.get(Integer.class)))))),
-                        allOf(methodName(equalTo("getInteger")), returnType(equalTo(ClassName.get(Integer.class))), codeContent(equalTo(
-                                "if ( !(anyType instanceof  java.lang.Integer)) throw new java.lang.IllegalStateException(\"fetching wrong type out of the union: java.lang.Integer\");\nreturn (java.lang.Integer) anyType;\n"))),
-                        allOf(methodName(equalTo("isInteger")), returnType(equalTo(ClassName.get(Boolean.class).unbox())), codeContent(equalTo("return anyType instanceof java.lang.Integer;\n"))),
-                        allOf(methodName(equalTo("<init>")), parameters(contains(type(equalTo(ClassName.get("bar.pack", "Second")))))),
-                        allOf(methodName(equalTo("getSecond")), returnType(equalTo(ClassName.get("bar.pack", "Second"))), codeContent(equalTo(
-                                "if ( !(anyType instanceof  bar.pack.Second)) throw new java.lang.IllegalStateException(\"fetching wrong type out of the union: bar.pack.Second\");\nreturn (bar.pack.Second) anyType;\n"))),
-                        allOf(methodName(equalTo("isSecond")), returnType(equalTo(ClassName.get(Boolean.class).unbox())), codeContent(equalTo("return anyType instanceof bar.pack.Second;\n")))
-                )),
-
-                superInterfaces(contains(
-                        allOf(typeName(equalTo(ClassName.get("bar.pack", "Foo"))))
-                ))
+        assertThat(r.getImplementation().get(), is(allOf(name(equalTo("FooImpl")),
+            fields(contains(
+                allOf(fieldName(equalTo("unionType")), fieldType(equalTo(ClassName.get("bar.pack", "Foo.UnionType")))),
+                allOf(fieldName(equalTo("integerValue")), fieldType(equalTo(ClassName.get(Integer.class)))),
+                allOf(fieldName(equalTo("secondValue")), fieldType(equalTo(ClassName.get("bar.pack", "Second"))))
+            )),
+            methods(contains(methodName(equalTo("<init>")),
+                allOf(methodName(equalTo("getUnionType")), returnType(equalTo(ClassName.get("bar.pack", "Foo.UnionType"))), codeContent(equalTo("return this.unionType;\n"))),
+                allOf(methodName(equalTo("<init>")),parameters(contains(type(equalTo(ClassName.get(Integer.class)))))),
+                allOf(methodName(equalTo("isInteger")),returnType(equalTo(ClassName.get(Boolean.class).unbox())),codeContent(equalTo("return this.unionType == bar.pack.Foo.UnionType.INTEGER;\n"))),
+                allOf(methodName(equalTo("getInteger")), returnType(equalTo(ClassName.get(Integer.class))),codeContent(equalTo("if (!isInteger()) throw new java.lang.IllegalStateException(\"fetching wrong type out of the union: java.lang.Integer\");\nreturn this.integerValue;\n"))),
+                allOf(methodName(equalTo("<init>")),parameters(contains(type(equalTo(ClassName.get("bar.pack", "Second")))))),
+                allOf(methodName(equalTo("isSecond")),returnType(equalTo(ClassName.get(Boolean.class).unbox())),codeContent(equalTo("return this.unionType == bar.pack.Foo.UnionType.SECOND;\n"))),
+                allOf(methodName(equalTo("getSecond")),returnType(equalTo(ClassName.get("bar.pack", "Second"))),codeContent(equalTo("if (!isSecond()) throw new java.lang.IllegalStateException(\"fetching wrong type out of the union: bar.pack.Second\");\nreturn this.secondValue;\n")))
+            )),
+            superInterfaces(contains(allOf(typeName(equalTo(ClassName.get("bar.pack", "Foo"))))))
         )));
-
     }
 
-    //@Test(expected = GenerationException.class)
+    // @Test(expected = GenerationException.class)
     public void arrayUnion() throws Exception {
 
         Api api = RamlLoader.load(this.getClass().getResourceAsStream("union-array-type.raml"), ".");
@@ -135,13 +121,51 @@ public class UnionTypeHandlerTest {
         handler.create(new GenerationContextImpl(PluginManager.NULL, api, TypeFetchers.fromTypes(), "bar.pack",Collections.<String>emptyList()), null);
     }
 
+    @Test
+    public void nilUnion() throws Exception {
+
+        Api api = RamlLoader.load(this.getClass().getResourceAsStream("union-nil-type.raml"), ".");
+        UnionTypeHandler handler = new UnionTypeHandler("foo", findTypes("foo", api.types()));
+
+        GenerationContextImpl generationContext = new GenerationContextImpl(PluginManager.NULL, api,TypeFetchers.fromTypes(), "bar.pack", Collections.<String>emptyList());
+        CreationResult r = handler.create(generationContext, new CreationResult(generationContext.defaultPackage(),ClassName.get("bar.pack", "Foo"), ClassName.get("bar.pack", "FooImpl"))).get();
+
+        assertThat(r.getInterface(), is(allOf(name(equalTo("Foo")), methods(contains(
+            allOf(methodName(equalTo("getUnionType")), returnType(equalTo(ClassName.get("bar.pack", "Foo.UnionType")))),
+            allOf(methodName(equalTo("isFirst")), returnType(equalTo(ClassName.get(Boolean.class).unbox()))),
+            allOf(methodName(equalTo("getFirst")), returnType(equalTo(ClassName.get("bar.pack", "First")))),
+            allOf(methodName(equalTo("isNil")), returnType(equalTo(ClassName.get(Boolean.class).unbox()))),
+            allOf(methodName(equalTo("getNil")), returnType(equalTo(ClassName.get("", "java.lang.Object"))))
+        )))));
+
+        System.err.println(r.getInterface().toString());
+        System.err.println(r.getImplementation().toString());
+
+        assertThat(r.getImplementation().get(), is(allOf(name(equalTo("FooImpl")),
+            fields(contains(
+                allOf(fieldName(equalTo("unionType")), fieldType(equalTo(ClassName.get("bar.pack", "Foo.UnionType")))),
+                allOf(fieldName(equalTo("firstValue")), fieldType(equalTo(ClassName.get("bar.pack", "First"))))
+            )),
+            methods(contains(allOf(methodName(equalTo("<init>"))),
+                allOf(methodName(equalTo("getUnionType")), returnType(equalTo(ClassName.get("bar.pack", "Foo.UnionType"))), codeContent(equalTo("return this.unionType;\n"))),
+                allOf(methodName(equalTo("<init>")),parameters(contains(type(equalTo(ClassName.get("bar.pack", "First")))))),
+                allOf(methodName(equalTo("isFirst")), returnType(equalTo(ClassName.get(Boolean.class).unbox())),codeContent(equalTo("return this.unionType == bar.pack.Foo.UnionType.FIRST;\n"))),
+                allOf(methodName(equalTo("getFirst")), returnType(equalTo(ClassName.get("bar.pack", "First"))),codeContent(equalTo("if (!isFirst()) throw new java.lang.IllegalStateException(\"fetching wrong type out of the union: bar.pack.First\");\nreturn this.firstValue;\n"))),
+                allOf(methodName(equalTo("isNil")), returnType(equalTo(ClassName.get(Boolean.class).unbox())),codeContent(equalTo("return this.unionType == bar.pack.Foo.UnionType.NIL;\n"))),
+                allOf(methodName(equalTo("getNil")), returnType(equalTo(ClassName.get("", "java.lang.Object"))),codeContent(equalTo("if (!isNil()) throw new java.lang.IllegalStateException(\"fetching wrong type out of the union: NullType should be null\");\nreturn null;\n")))
+            )),
+            superInterfaces(contains(allOf(typeName(equalTo(ClassName.get("bar.pack", "Foo"))))))
+        )));
+    }
+
     private static UnionTypeDeclaration findTypes(final String name, List<TypeDeclaration> types) {
         return (UnionTypeDeclaration) FluentIterable.from(types).firstMatch(new Predicate<TypeDeclaration>() {
+
             @Override
             public boolean apply(@Nullable TypeDeclaration input) {
                 return input.name().equals(name);
             }
+
         }).get();
     }
-
 }

--- a/raml-to-pojo/src/test/resources/org/raml/ramltopojo/extensions/jackson2/union-ambiguous-type.raml
+++ b/raml-to-pojo/src/test/resources/org/raml/ramltopojo/extensions/jackson2/union-ambiguous-type.raml
@@ -1,0 +1,13 @@
+#%RAML 1.0
+title: Hello World API
+version: v1
+baseUri: https://api.github.com
+types:
+  
+    Email:
+      type: string
+  
+    Foo:
+      type: object
+      properties:
+        prop: Email | string

--- a/raml-to-pojo/src/test/resources/org/raml/ramltopojo/extensions/jackson2/union-mix-type.raml
+++ b/raml-to-pojo/src/test/resources/org/raml/ramltopojo/extensions/jackson2/union-mix-type.raml
@@ -1,0 +1,21 @@
+#%RAML 1.0
+title: Hello World API
+version: v1
+baseUri: https://api.github.com
+types:
+  
+    email:
+      type: string
+      minLength: 1
+      pattern: ^/.*$
+      
+    baa:
+      type: object
+      properties:
+        first: integer
+        second: string
+  
+    foo:
+      type: object
+      properties:
+        prop: baa | email | boolean | integer | nil

--- a/raml-to-pojo/src/test/resources/org/raml/ramltopojo/extensions/jsr303/union-type.raml
+++ b/raml-to-pojo/src/test/resources/org/raml/ramltopojo/extensions/jsr303/union-type.raml
@@ -1,0 +1,13 @@
+#%RAML 1.0
+title: Hello World API
+version: v1
+baseUri: https://api.github.com
+types:
+  
+    email:
+      type: string
+      minLength: 1
+      pattern: ^/.*$
+  
+    foo:
+      type: email | nil

--- a/raml-to-pojo/src/test/resources/org/raml/ramltopojo/union/complex-union.raml
+++ b/raml-to-pojo/src/test/resources/org/raml/ramltopojo/union/complex-union.raml
@@ -1,0 +1,208 @@
+#%RAML 1.0
+title: Hello World API
+version: v1
+baseUri: https://api.github.com
+
+# ------------------------------------------------------------------------------
+# - TYPES
+# ------------------------------------------------------------------------------     
+     
+types:
+ 
+  DtoMediumString:
+    type: string
+    maxLength: 256
+    
+  DtoLongString:
+    type: string
+    maxLength: 4096
+    
+  DtoUuid:
+    type: string
+    pattern: ^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$
+    
+  DtoPath:
+    type: DtoMediumString
+    minLength: 1
+    pattern: ^/.*$
+    
+  DtoId:
+    type: DtoMediumString
+    minLength: 1
+    pattern: ^\S+$
+    
+  DtoHref:
+    type: DtoMediumString
+    minLength: 1
+    pattern: ^https://.*$
+    
+  DtoTime:
+    type: integer
+    format: int64
+    
+  DtoSha1:
+    type: string
+    pattern: ^[a-f0-9]{40}$
+    
+  DtoSemVer:
+    type: DtoMediumString
+    pattern: ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$ 
+    
+  DtoTenantId:
+    type: string
+    pattern: ^[1-9]\d{2,}$
+    example: '666'
+    
+  DtoQuery:
+    type: string
+    pattern: ;[^/]+
+    #TODO
+
+  # ------------------------------------------------------------------------------
+  # Exceptions 
+  # ------------------------------------------------------------------------------
+  
+  DtoException:
+    type: object
+    discriminator: _type
+    properties:
+      _type:
+        type: string
+    #TODO: Further properties
+  DtoIllegalAuthenticationException:
+    type: DtoException
+    #TODO: Further properties
+  DtoPermissionDeniedException:
+    type: DtoException
+    #TODO: Further properties
+  DtoBodyParseException:
+    type: DtoException
+    #TODO: Further properties
+  DtoValueInUseException:
+    type: DtoException
+    #TODO: Further properties
+  DtoQuerySyntaxException:
+    type: DtoException
+    #TODO: Further properties
+  DtoQueryResultException:
+    type: DtoException
+    #TODO: Further properties
+        
+  # ------------------------------------------------------------------------------
+  # Database Entity 
+  # ------------------------------------------------------------------------------ 
+        
+  DtoDatabaseEntity:
+    type: object
+    discriminator: _type
+    properties:
+      _type:
+        type: string
+      uuid?:
+        type: DtoUuid
+      path?:
+        type: DtoPath
+      id?:
+        type: DtoId
+      version?:
+        type: integer
+        format: int64
+        minimum: 0
+        default: 0
+      label?:
+        type: DtoMediumString
+      description?:
+        type: DtoLongString
+      retentionPolicy?:
+        type: DtoRetentionPolicy
+      tags?:
+        type: DtoTags
+      createdBy?:
+        type: DtoAuthor
+      createdOn?:
+        type: DtoTime
+      updatedBy?:
+        type: DtoAuthor
+      updatedOn?:
+        type: DtoTime
+        
+  DtoRetentionPolicy:
+    type: object
+    properties:
+      deleteOn: 
+        type: DtoTime | nil
+        
+  DtoTags:
+    type: object
+    properties:
+      //:
+        type: DtoMediumString
+        minLength: 1
+    
+  DtoAuthor:
+    type: object
+    properties:
+      id:
+        type: DtoId
+      label:
+        type: DtoMediumString
+      profileHref:
+        type: DtoHref | nil
+
+
+  # ------------------------------------------------------------------------------
+  # App Info 
+  # ------------------------------------------------------------------------------     
+    
+  DtoAppInfo:
+    type: object
+    properties:
+      id:
+        type: DtoId
+      label:
+        type: DtoMediumString
+      description:
+        type: DtoLongString
+      project:
+        type: DtoId
+      vendor:
+        type: DtoMediumString
+      version:
+        type: DtoSemVer
+      build:
+        type: DtoAppBuildInfo | nil
+        
+  DtoAppBuildInfo:
+    type: object
+    properties:
+      id:
+        type: DtoId
+      time:
+        type: DtoTime
+      commit:
+        type: DtoSha1
+
+  DtoContact:
+    type: DtoDatabaseEntity
+    discriminatorValue: DtoContact
+    properties:
+      firstName:
+        type: DtoMediumString
+        minLength: 1
+      surname:
+        type: DtoMediumString
+        minLength: 1
+      email:
+        type: DtoEmail | nil
+      phone:
+        type: DtoPhone | nil
+        
+  DtoEmail:
+    type: DtoMediumString
+    minLength: 1
+    pattern: ^\S+@\S+$
+    
+  DtoPhone:
+    type: DtoMediumString
+    minLength: 1
+    pattern: ^\+[1-9]\d \d+ \d+$    

--- a/test-utils/src/main/java/org/raml/testutils/matchers/AnnotationSpecMatchers.java
+++ b/test-utils/src/main/java/org/raml/testutils/matchers/AnnotationSpecMatchers.java
@@ -1,12 +1,9 @@
 /*
  * Copyright 2013-2017 (c) MuleSoft, Inc.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
@@ -17,6 +14,8 @@ package org.raml.testutils.matchers;
 
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.TypeName;
+
 import org.hamcrest.Description;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
@@ -27,32 +26,43 @@ import org.hamcrest.TypeSafeMatcher;
  */
 public class AnnotationSpecMatchers {
 
-  public static Matcher<AnnotationSpec> hasMember(final String member) {
+    public static <K extends TypeName> Matcher<AnnotationSpec> annotationType(Matcher<K> match) {
 
-    return new TypeSafeMatcher<AnnotationSpec>() {
+        return new FeatureMatcher<AnnotationSpec, K>(match, "annotation type", "annotation type") {
 
-      @Override
-      protected boolean matchesSafely(AnnotationSpec item) {
-        return item.members.containsKey(member);
-      }
+            @Override
+            protected K featureValueOf(AnnotationSpec actual) {
+                return (K) actual.type;
+            }
+        };
+    }
 
-      @Override
-      public void describeTo(Description description) {
+    public static Matcher<AnnotationSpec> hasMember(final String member) {
 
-        description.appendText("has member " + member);
-      }
-    };
-  }
+        return new TypeSafeMatcher<AnnotationSpec>() {
 
-  public static Matcher<AnnotationSpec> member(final String member, Matcher<Iterable<? extends CodeBlock>> memberMatcher) {
+            @Override
+            protected boolean matchesSafely(AnnotationSpec item) {
+                return item.members.containsKey(member);
+            }
 
-    return new FeatureMatcher<AnnotationSpec, Iterable<? extends CodeBlock>>(memberMatcher, "member", "member") {
+            @Override
+            public void describeTo(Description description) {
 
-      @Override
-      protected Iterable<? extends CodeBlock> featureValueOf(AnnotationSpec actual) {
+                description.appendText("has member " + member);
+            }
+        };
+    }
 
-        return actual.members.get(member);
-      }
-    };
-  }
+    public static Matcher<AnnotationSpec> member(final String member, Matcher<Iterable<? extends CodeBlock>> memberMatcher) {
+
+        return new FeatureMatcher<AnnotationSpec, Iterable<? extends CodeBlock>>(memberMatcher, "member", "member") {
+
+            @Override
+            protected Iterable<? extends CodeBlock> featureValueOf(AnnotationSpec actual) {
+
+                return actual.members.get(member);
+            }
+        };
+    }
 }

--- a/test-utils/src/main/java/org/raml/testutils/matchers/FieldSpecMatchers.java
+++ b/test-utils/src/main/java/org/raml/testutils/matchers/FieldSpecMatchers.java
@@ -1,12 +1,9 @@
 /*
  * Copyright 2013-2017 (c) MuleSoft, Inc.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
@@ -15,8 +12,10 @@
  */
 package org.raml.testutils.matchers;
 
+import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.TypeName;
+
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 
@@ -25,37 +24,49 @@ import org.hamcrest.Matcher;
  */
 public class FieldSpecMatchers {
 
-  public static Matcher<FieldSpec> fieldName(Matcher<String> match) {
+    public static Matcher<FieldSpec> fieldName(Matcher<String> match) {
 
-    return new FeatureMatcher<FieldSpec, String>(match, "field name", "field name") {
+        return new FeatureMatcher<FieldSpec, String>(match, "field name", "field name") {
 
-      @Override
-      protected String featureValueOf(FieldSpec actual) {
-        return actual.name;
-      }
-    };
-  }
+            @Override
+            protected String featureValueOf(FieldSpec actual) {
+                return actual.name;
+            }
+        };
+    }
 
-  public static Matcher<FieldSpec> initializer(Matcher<String> match) {
+    public static Matcher<FieldSpec> initializer(Matcher<String> match) {
 
-    return new FeatureMatcher<FieldSpec, String>(match, "field initializer", "field initializer") {
+        return new FeatureMatcher<FieldSpec, String>(match, "field initializer", "field initializer") {
 
-      @Override
-      protected String featureValueOf(FieldSpec actual) {
-        return actual.initializer.toString();
-      }
-    };
-  }
+            @Override
+            protected String featureValueOf(FieldSpec actual) {
+                return actual.initializer.toString();
+            }
+        };
+    }
 
-  public static <T extends TypeName> Matcher<FieldSpec> fieldType(Matcher<T> match) {
+    public static <T extends TypeName> Matcher<FieldSpec> fieldType(Matcher<T> match) {
 
-    return new FeatureMatcher<FieldSpec, T>(match, "type name", "type name") {
+        return new FeatureMatcher<FieldSpec, T>(match, "type name", "type name") {
 
-      @Override
-      protected T featureValueOf(FieldSpec actual) {
-        return (T) actual.type;
-      }
-    };
-  }
+            @Override
+            protected T featureValueOf(FieldSpec actual) {
+                return (T) actual.type;
+            }
+        };
+    }
+
+    public static Matcher<FieldSpec> fieldAnnotations(Matcher<Iterable<? extends AnnotationSpec>> typeMatcher) {
+
+        return new FeatureMatcher<FieldSpec, Iterable<? extends AnnotationSpec>>(typeMatcher, "field annotation", "field annotation") {
+
+            @Override
+            protected Iterable<? extends AnnotationSpec> featureValueOf(FieldSpec actual) {
+
+                return actual.annotations;
+            }
+        };
+    }
 
 }

--- a/test-utils/src/main/java/org/raml/testutils/matchers/TypeSpecMatchers.java
+++ b/test-utils/src/main/java/org/raml/testutils/matchers/TypeSpecMatchers.java
@@ -1,12 +1,9 @@
 /*
  * Copyright 2013-2017 (c) MuleSoft, Inc.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
@@ -15,6 +12,7 @@
  */
 package org.raml.testutils.matchers;
 
+import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeName;
@@ -27,63 +25,75 @@ import org.hamcrest.Matcher;
  */
 public class TypeSpecMatchers {
 
-  public static Matcher<TypeSpec> name(Matcher<String> match) {
+    public static Matcher<TypeSpec> name(Matcher<String> match) {
 
-    return new FeatureMatcher<TypeSpec, String>(match, "type name", "type name") {
+        return new FeatureMatcher<TypeSpec, String>(match, "type name", "type name") {
 
-      @Override
-      protected String featureValueOf(TypeSpec actual) {
-        return actual.name;
-      }
-    };
-  }
+            @Override
+            protected String featureValueOf(TypeSpec actual) {
+                return actual.name;
+            }
+        };
+    }
 
-  public static Matcher<TypeSpec> superInterfaces(Matcher<Iterable<? extends TypeName>> memberMatcher) {
+    public static Matcher<TypeSpec> superInterfaces(Matcher<Iterable<? extends TypeName>> memberMatcher) {
 
-    return new FeatureMatcher<TypeSpec, Iterable<? extends TypeName>>(memberMatcher, "super interfaces", "super interfaces") {
+        return new FeatureMatcher<TypeSpec, Iterable<? extends TypeName>>(memberMatcher, "super interfaces", "super interfaces") {
 
-      @Override
-      protected Iterable<? extends TypeName> featureValueOf(TypeSpec actual) {
+            @Override
+            protected Iterable<? extends TypeName> featureValueOf(TypeSpec actual) {
 
-        return actual.superinterfaces;
-      }
-    };
-  }
+                return actual.superinterfaces;
+            }
+        };
+    }
 
-  public static Matcher<TypeSpec> methods(Matcher<Iterable<? extends MethodSpec>> memberMatcher) {
+    public static Matcher<TypeSpec> methods(Matcher<Iterable<? extends MethodSpec>> memberMatcher) {
 
-    return new FeatureMatcher<TypeSpec, Iterable<? extends MethodSpec>>(memberMatcher, "method", "method") {
+        return new FeatureMatcher<TypeSpec, Iterable<? extends MethodSpec>>(memberMatcher, "method", "method") {
 
-      @Override
-      protected Iterable<? extends MethodSpec> featureValueOf(TypeSpec actual) {
+            @Override
+            protected Iterable<? extends MethodSpec> featureValueOf(TypeSpec actual) {
 
-        return actual.methodSpecs;
-      }
-    };
-  }
+                return actual.methodSpecs;
+            }
+        };
+    }
 
-  public static Matcher<TypeSpec> fields(Matcher<Iterable<? extends FieldSpec>> memberMatcher) {
+    public static Matcher<TypeSpec> fields(Matcher<Iterable<? extends FieldSpec>> memberMatcher) {
 
-    return new FeatureMatcher<TypeSpec, Iterable<? extends FieldSpec>>(memberMatcher, "field", "field") {
+        return new FeatureMatcher<TypeSpec, Iterable<? extends FieldSpec>>(memberMatcher, "field", "field") {
 
-      @Override
-      protected Iterable<? extends FieldSpec> featureValueOf(TypeSpec actual) {
+            @Override
+            protected Iterable<? extends FieldSpec> featureValueOf(TypeSpec actual) {
 
-        return actual.fieldSpecs;
-      }
-    };
-  }
+                return actual.fieldSpecs;
+            }
+        };
+    }
 
-  public static Matcher<TypeSpec> innerTypes(Matcher<Iterable<? extends TypeSpec>> typeMatcher) {
+    public static Matcher<TypeSpec> innerTypes(Matcher<Iterable<? extends TypeSpec>> typeMatcher) {
 
-    return new FeatureMatcher<TypeSpec, Iterable<? extends TypeSpec>>(typeMatcher, "inner type", "inner type") {
+        return new FeatureMatcher<TypeSpec, Iterable<? extends TypeSpec>>(typeMatcher, "inner type", "inner type") {
 
-      @Override
-      protected Iterable<? extends TypeSpec> featureValueOf(TypeSpec actual) {
+            @Override
+            protected Iterable<? extends TypeSpec> featureValueOf(TypeSpec actual) {
 
-        return actual.typeSpecs;
-      }
-    };
-  }
+                return actual.typeSpecs;
+            }
+        };
+    }
+
+    public static Matcher<TypeSpec> annotations(Matcher<Iterable<? extends AnnotationSpec>> typeMatcher) {
+
+        return new FeatureMatcher<TypeSpec, Iterable<? extends AnnotationSpec>>(typeMatcher, "annotation", "annotation") {
+
+            @Override
+            protected Iterable<? extends AnnotationSpec> featureValueOf(TypeSpec actual) {
+
+                return actual.annotations;
+            }
+        };
+    }
 
 }


### PR DESCRIPTION
Here is my Pull request for Ticket #39 

Following things changed:

- Changed complete behaviour of Jackson-Deserialization
  - Don't use deserialize to Map anymore, use JsonNode instead
  - Added deserialization strategy for every TypeDeclaration
  - Unions, Arrays and Any Types are not supported
  - Sorting of types for better deserialization (integer before number)
- All Unions are working fine:
  - Objects, nil and primitive types
  - Inline declaration and type declaration
- Throwing an Ambiguous Exception if ambiguous types are used
  - This needs to be done as two String types cannot be distinguished when in Json Format anymore
- Changed ObjectCreation for Unions to create correct inline types
- Changed structure of Unions:
  - Changed union name (string | integer | nil => StringIntegerNilUnion)
  - Instead of one "any-field" all types have their own field (anyfield was removed)
  - This is needed, as validation cannot be done on a single field (imagine a Email (string with pattern) and nil union)
  - Created enum of types in unions to allow Switch statements, not asking every field
- Added field creation to JSR303 to add validation for union fields
- Changed naming of union fields to match the given type (Email (type String)) is now used as Email and not as String anymore (isEmail, getEmail)
- Moved implementation from jackson2 to jackson (without jackson2 stuff)
- Added jackson2 test
- Added validation test
- Fixed some formatting in SpecMatchers
