### PR TITLE
buildLooksLike to filter out the non-mandatory TypeDeclaration

### DIFF
--- a/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jackson1/JacksonUnionExtension.java
+++ b/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jackson1/JacksonUnionExtension.java
@@ -1,9 +1,14 @@
 package org.raml.ramltopojo.extensions.jackson1;
 
-import com.google.common.base.Function;
-import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
-import com.squareup.javapoet.*;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+import javax.lang.model.element.Modifier;
+
 import org.codehaus.jackson.JsonGenerator;
 import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.JsonProcessingException;
@@ -22,156 +27,139 @@ import org.raml.v2.api.model.v10.datamodel.ObjectTypeDeclaration;
 import org.raml.v2.api.model.v10.datamodel.TypeDeclaration;
 import org.raml.v2.api.model.v10.datamodel.UnionTypeDeclaration;
 
-import javax.annotation.Nullable;
-import javax.lang.model.element.Modifier;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
 
 /**
  * Created. There, you have it.
  */
 public class JacksonUnionExtension extends UnionTypeHandlerPlugin.Helper {
 
-    @Override
-    public ClassName className(UnionPluginContext unionPluginContext, UnionTypeDeclaration ramlType, ClassName currentSuggestion, EventType eventType) {
-        return currentSuggestion;
-    }
+	@Override
+	public ClassName className(UnionPluginContext unionPluginContext, UnionTypeDeclaration ramlType, ClassName currentSuggestion, EventType eventType) {
+		return currentSuggestion;
+	}
 
-    @Override
-    public TypeSpec.Builder classCreated(UnionPluginContext unionPluginContext, UnionTypeDeclaration ramlType, TypeSpec.Builder incoming, EventType eventType) {
+	@Override
+	public TypeSpec.Builder classCreated(UnionPluginContext unionPluginContext, UnionTypeDeclaration ramlType, TypeSpec.Builder incoming, EventType eventType) {
 
-        ClassName deserializer =
-                ClassName.get("", unionPluginContext.creationResult().getJavaName(EventType.INTERFACE).simpleName(),
-                        Names.typeName(ramlType.name(), "deserializer"));
+		ClassName deserializer = ClassName.get("", unionPluginContext.creationResult().getJavaName(EventType.INTERFACE).simpleName(),
+				Names.typeName(ramlType.name(), "deserializer"));
 
-        ClassName serializer =
-                ClassName.get("", unionPluginContext.creationResult().getJavaName(EventType.INTERFACE).simpleName(),
-                        Names.typeName("serializer"));
+		ClassName serializer = ClassName.get("", unionPluginContext.creationResult().getJavaName(EventType.INTERFACE).simpleName(), Names.typeName("serializer"));
 
-        createSerializer(serializer, ramlType, incoming, eventType);
-        createDeserializer(unionPluginContext, deserializer, ramlType, incoming, eventType);
+		createSerializer(serializer, ramlType, incoming, eventType);
+		createDeserializer(unionPluginContext, deserializer, ramlType, incoming, eventType);
 
-        incoming.addAnnotation(AnnotationSpec.builder(JsonDeserialize.class)
-                .addMember("using", "$T.class", deserializer).build());
-        incoming.addAnnotation(AnnotationSpec.builder(JsonSerialize.class)
-                .addMember("using", "$T.class", serializer).build());
+		incoming.addAnnotation(AnnotationSpec.builder(JsonDeserialize.class).addMember("using", "$T.class", deserializer).build());
+		incoming.addAnnotation(AnnotationSpec.builder(JsonSerialize.class).addMember("using", "$T.class", serializer).build());
 
-        return incoming;
-    }
+		return incoming;
+	}
 
-    private void createSerializer(ClassName serializerName, UnionTypeDeclaration union, TypeSpec.Builder typeBuilder, EventType eventType) {
+	private void createSerializer(ClassName serializerName, UnionTypeDeclaration union, TypeSpec.Builder typeBuilder, EventType eventType) {
 
-        if ( eventType == EventType.IMPLEMENTATION) {
-            return;
-        }
+		if (eventType == EventType.IMPLEMENTATION) {
+			return;
+		}
 
-        ClassName typeBuilderName = ClassName.get("", typeBuilder.build().name);
-        TypeSpec.Builder builder = TypeSpec.classBuilder(serializerName)
-                .addModifiers(Modifier.STATIC, Modifier.PUBLIC)
-                .superclass(ParameterizedTypeName.get(ClassName.get(SerializerBase.class), typeBuilderName))
-                .addMethod(
-                        MethodSpec.constructorBuilder()
-                                .addModifiers(Modifier.PUBLIC)
-                                .addCode("super($T.class);", typeBuilderName).build()
+		ClassName typeBuilderName = ClassName.get("", typeBuilder.build().name);
+		TypeSpec.Builder builder = TypeSpec.classBuilder(serializerName).addModifiers(Modifier.STATIC, Modifier.PUBLIC)
+				.superclass(ParameterizedTypeName.get(ClassName.get(SerializerBase.class), typeBuilderName))
+				.addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC).addCode("super($T.class);", typeBuilderName).build()
 
-                ).addModifiers(Modifier.PUBLIC);
-        MethodSpec.Builder serialize = MethodSpec.methodBuilder("serialize")
-                .addModifiers(Modifier.PUBLIC)
-                .addParameter(ParameterSpec.builder(typeBuilderName, "object").build())
-                .addParameter(ParameterSpec.builder(ClassName.get(JsonGenerator.class), "jsonGenerator").build())
-                .addParameter(ParameterSpec.builder(ClassName.get(SerializerProvider.class), "jsonSerializerProvider").build())
-                .addException(IOException.class)
-                .addException(JsonProcessingException.class);
+				).addModifiers(Modifier.PUBLIC);
+		MethodSpec.Builder serialize = MethodSpec.methodBuilder("serialize").addModifiers(Modifier.PUBLIC).addParameter(ParameterSpec.builder(typeBuilderName, "object").build())
+				.addParameter(ParameterSpec.builder(ClassName.get(JsonGenerator.class), "jsonGenerator").build())
+				.addParameter(ParameterSpec.builder(ClassName.get(SerializerProvider.class), "jsonSerializerProvider").build()).addException(IOException.class)
+				.addException(JsonProcessingException.class);
 
-        for (TypeDeclaration typeDeclaration : union.of()) {
+		for (TypeDeclaration typeDeclaration : union.of()) {
 
-            String isMethod = Names.methodName("is", typeDeclaration.name());
-            String getMethod = Names.methodName("get", typeDeclaration.name());
-            serialize.beginControlFlow("if ( object." + isMethod + "())");
-            serialize.addStatement("jsonGenerator.writeObject(object." + getMethod + "())");
-            serialize.addStatement("return");
-            serialize.endControlFlow();
-        }
+			String isMethod = Names.methodName("is", typeDeclaration.name());
+			String getMethod = Names.methodName("get", typeDeclaration.name());
+			serialize.beginControlFlow("if ( object." + isMethod + "())");
+			serialize.addStatement("jsonGenerator.writeObject(object." + getMethod + "())");
+			serialize.addStatement("return");
+			serialize.endControlFlow();
+		}
 
-        serialize.addStatement("throw new $T($S + object)", IOException.class, "Can't figure out type of object");
+		serialize.addStatement("throw new $T($S + object)", IOException.class, "Can't figure out type of object");
 
-        builder.addMethod(serialize.build());
-        typeBuilder.addType(builder.build());
-    }
+		builder.addMethod(serialize.build());
+		typeBuilder.addType(builder.build());
+	}
 
-    private void createDeserializer(UnionPluginContext unionPluginContext, ClassName serializerName, UnionTypeDeclaration union, TypeSpec.Builder typeBuilder, EventType eventType) {
+	private void createDeserializer(UnionPluginContext unionPluginContext, ClassName serializerName, UnionTypeDeclaration union, TypeSpec.Builder typeBuilder,
+			EventType eventType) {
 
-        if ( eventType == EventType.IMPLEMENTATION) {
-            return;
-        }
+		if (eventType == EventType.IMPLEMENTATION) {
+			return;
+		}
 
-        ClassName typeBuilderName = ClassName.get("", typeBuilder.build().name);
+		ClassName typeBuilderName = ClassName.get("", typeBuilder.build().name);
 
-        TypeSpec.Builder builder = TypeSpec.classBuilder(serializerName)
-                .addModifiers(Modifier.STATIC, Modifier.PUBLIC)
-                .superclass(ParameterizedTypeName.get(ClassName.get(StdDeserializer.class), typeBuilderName))
-                .addMethod(
-                        MethodSpec.constructorBuilder()
-                                .addModifiers(Modifier.PUBLIC)
-                                .addCode("super($T.class);", typeBuilderName).build()
+		TypeSpec.Builder builder = TypeSpec.classBuilder(serializerName).addModifiers(Modifier.STATIC, Modifier.PUBLIC)
+				.superclass(ParameterizedTypeName.get(ClassName.get(StdDeserializer.class), typeBuilderName))
+				.addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC).addCode("super($T.class);", typeBuilderName).build()
 
-                ).addModifiers(Modifier.PUBLIC);
+				).addModifiers(Modifier.PUBLIC);
 
-        MethodSpec.Builder deserialize = MethodSpec.methodBuilder("deserialize")
-                .addModifiers(Modifier.PUBLIC)
-                .addParameter(ParameterSpec.builder(ClassName.get(JsonParser.class), "jsonParser").build())
-                .addParameter(ParameterSpec.builder(ClassName.get(DeserializationContext.class), "jsonContext").build())
-                .addException(IOException.class)
-                .addException(JsonProcessingException.class)
-                .returns(typeBuilderName)
-                .addStatement("$T mapper  = new $T()", ObjectMapper.class, ObjectMapper.class)
-                .addStatement("$T<String, Object> map = mapper.readValue(jsonParser, Map.class)", Map.class);
+		MethodSpec.Builder deserialize = MethodSpec.methodBuilder("deserialize").addModifiers(Modifier.PUBLIC)
+				.addParameter(ParameterSpec.builder(ClassName.get(JsonParser.class), "jsonParser").build())
+				.addParameter(ParameterSpec.builder(ClassName.get(DeserializationContext.class), "jsonContext").build()).addException(IOException.class)
+				.addException(JsonProcessingException.class).returns(typeBuilderName).addStatement("$T mapper  = new $T()", ObjectMapper.class, ObjectMapper.class)
+				.addStatement("$T<String, Object> map = mapper.readValue(jsonParser, Map.class)", Map.class);
 
+		for (TypeDeclaration typeDeclaration : union.of()) {
 
-        for (TypeDeclaration typeDeclaration : union.of()) {
+			TypeName unionPossibility = unionPluginContext.unionClass(typeDeclaration).getJavaName(EventType.IMPLEMENTATION);
 
-            TypeName unionPossibility = unionPluginContext.unionClass(typeDeclaration).getJavaName(EventType.IMPLEMENTATION);
+			String name = Names.methodName("looksLike", typeDeclaration.name());
+			deserialize.addStatement("if ( " + name + "(map) ) return new $T(mapper.convertValue(map, $T.class))",
+					unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), unionPossibility);
 
-            String name = Names.methodName("looksLike", typeDeclaration.name());
-            deserialize.addStatement("if ( " + name + "(map) ) return new $T(mapper.convertValue(map, $T.class))",
-                    unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), unionPossibility);
+			buildLooksLike(builder, typeDeclaration);
+		}
 
-            buildLooksLike(builder, typeDeclaration);
-        }
+		deserialize.addStatement("throw new $T($S + map)", IOException.class, "Can't figure out type of object");
+		builder.addMethod(deserialize.build());
 
+		typeBuilder.addType(builder.build());
+	}
 
-        deserialize.addStatement("throw new $T($S + map)", IOException.class, "Can't figure out type of object");
-        builder.addMethod(deserialize.build());
+	private void buildLooksLike(TypeSpec.Builder builder, TypeDeclaration typeDeclaration) {
 
-        typeBuilder.addType(builder.build());
-    }
+		String name = Names.methodName("looksLike", typeDeclaration.name());
+		MethodSpec.Builder spec = MethodSpec.methodBuilder(name)
+				.addParameter(ParameterizedTypeName.get(ClassName.get(Map.class), ClassName.get(String.class), ClassName.get(Object.class)), "map");
+		if (typeDeclaration instanceof ObjectTypeDeclaration) {
 
-    private void buildLooksLike(TypeSpec.Builder builder, TypeDeclaration typeDeclaration) {
+			ObjectTypeDeclaration otd = (ObjectTypeDeclaration) typeDeclaration;
+			List<TypeDeclaration> mandatoryProperties = otd.properties().stream().filter(propertyTypeDeclaration -> propertyTypeDeclaration.required())
+					.collect(Collectors.toList());
+			List<String> names = Lists.transform(mandatoryProperties, new Function<TypeDeclaration, String>() {
 
-        String name = Names.methodName("looksLike", typeDeclaration.name());
-        MethodSpec.Builder spec =
-                MethodSpec.methodBuilder(name).addParameter(ParameterizedTypeName.get(ClassName.get(Map.class),
-                        ClassName.get(String.class),
-                        ClassName.get(Object.class)), "map");
-        if (typeDeclaration instanceof ObjectTypeDeclaration) {
+				@Nullable
+				@Override
+				public String apply(@Nullable TypeDeclaration input) {
+					return "\"" + input.name() + "\"";
+				}
+			});
 
-            ObjectTypeDeclaration otd = (ObjectTypeDeclaration) typeDeclaration;
-            List<String> names = Lists.transform(otd.properties(), new Function<TypeDeclaration, String>() {
+			spec.addStatement("return map.keySet().containsAll($T.asList($L))", Arrays.class, Joiner.on(",").join(names));
+		}
 
-                @Nullable
-                @Override
-                public String apply(@Nullable TypeDeclaration input) {
-                    return "\"" + input.name() + "\"";
-                }
-            });
-
-            spec.addStatement("return map.keySet().containsAll($T.asList($L))", Arrays.class, Joiner.on(",").join(names));
-        }
-
-        spec.addModifiers(Modifier.PRIVATE).returns(TypeName.BOOLEAN);
-        builder.addMethod(spec.build());
-    }
+		spec.addModifiers(Modifier.PRIVATE).returns(TypeName.BOOLEAN);
+		builder.addMethod(spec.build());
+	}
 
 }

--- a/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jackson2/JacksonUnionExtension.java
+++ b/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/jackson2/JacksonUnionExtension.java
@@ -1,5 +1,23 @@
 package org.raml.ramltopojo.extensions.jackson2;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+import javax.lang.model.element.Modifier;
+
+import org.raml.ramltopojo.EventType;
+import org.raml.ramltopojo.Names;
+import org.raml.ramltopojo.extensions.UnionPluginContext;
+import org.raml.ramltopojo.extensions.UnionTypeHandlerPlugin;
+import org.raml.v2.api.model.v10.datamodel.ObjectTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.TypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.UnionTypeDeclaration;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -13,204 +31,173 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
-import com.squareup.javapoet.*;
-import org.raml.ramltopojo.EventType;
-import org.raml.ramltopojo.Names;
-import org.raml.ramltopojo.extensions.UnionPluginContext;
-import org.raml.ramltopojo.extensions.UnionTypeHandlerPlugin;
-import org.raml.v2.api.model.v10.datamodel.ObjectTypeDeclaration;
-import org.raml.v2.api.model.v10.datamodel.TypeDeclaration;
-import org.raml.v2.api.model.v10.datamodel.UnionTypeDeclaration;
-
-import javax.annotation.Nullable;
-import javax.lang.model.element.Modifier;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
 
 /**
  * Created. There, you have it.
  */
 public class JacksonUnionExtension extends UnionTypeHandlerPlugin.Helper {
 
-    @Override
-    public ClassName className(UnionPluginContext unionPluginContext, UnionTypeDeclaration ramlType, ClassName currentSuggestion, EventType eventType) {
-        return currentSuggestion;
-    }
+	@Override
+	public ClassName className(UnionPluginContext unionPluginContext, UnionTypeDeclaration ramlType, ClassName currentSuggestion, EventType eventType) {
+		return currentSuggestion;
+	}
 
-    @Override
-    public TypeSpec.Builder classCreated(UnionPluginContext unionPluginContext, UnionTypeDeclaration ramlType, TypeSpec.Builder incoming, EventType eventType) {
+	@Override
+	public TypeSpec.Builder classCreated(UnionPluginContext unionPluginContext, UnionTypeDeclaration ramlType, TypeSpec.Builder incoming, EventType eventType) {
 
-        ClassName deserializer =
-                ClassName.get("", unionPluginContext.creationResult().getJavaName(EventType.INTERFACE).simpleName(),
-                        Names.typeName(ramlType.name(), "deserializer"));
+		ClassName deserializer = ClassName.get("", unionPluginContext.creationResult().getJavaName(EventType.INTERFACE).simpleName(),
+				Names.typeName(ramlType.name(), "deserializer"));
 
-        ClassName serializer =
-                ClassName.get("", unionPluginContext.creationResult().getJavaName(EventType.INTERFACE).simpleName(),
-                        Names.typeName("serializer"));
+		ClassName serializer = ClassName.get("", unionPluginContext.creationResult().getJavaName(EventType.INTERFACE).simpleName(), Names.typeName("serializer"));
 
-        createSerializer(serializer, ramlType, incoming, eventType);
-        createDeserializer(unionPluginContext, deserializer, ramlType, incoming, eventType);
+		createSerializer(serializer, ramlType, incoming, eventType);
+		createDeserializer(unionPluginContext, deserializer, ramlType, incoming, eventType);
 
-        incoming.addAnnotation(AnnotationSpec.builder(JsonDeserialize.class)
-                .addMember("using", "$T.class", deserializer).build());
-        incoming.addAnnotation(AnnotationSpec.builder(JsonSerialize.class)
-                .addMember("using", "$T.class", serializer).build());
+		incoming.addAnnotation(AnnotationSpec.builder(JsonDeserialize.class).addMember("using", "$T.class", deserializer).build());
+		incoming.addAnnotation(AnnotationSpec.builder(JsonSerialize.class).addMember("using", "$T.class", serializer).build());
 
-        return incoming;
-    }
+		return incoming;
+	}
 
-    private void createSerializer(ClassName serializerName, UnionTypeDeclaration union, TypeSpec.Builder typeBuilder, EventType eventType) {
+	private void createSerializer(ClassName serializerName, UnionTypeDeclaration union, TypeSpec.Builder typeBuilder, EventType eventType) {
 
-        if ( eventType == EventType.IMPLEMENTATION) {
-            return;
-        }
+		if (eventType == EventType.IMPLEMENTATION) {
+			return;
+		}
 
-        ClassName typeBuilderName = ClassName.get("", typeBuilder.build().name);
-        TypeSpec.Builder builder = TypeSpec.classBuilder(serializerName)
-                .addModifiers(Modifier.STATIC, Modifier.PUBLIC)
-                .superclass(ParameterizedTypeName.get(ClassName.get(StdSerializer.class), typeBuilderName))
-                .addMethod(
-                        MethodSpec.constructorBuilder()
-                                .addModifiers(Modifier.PUBLIC)
-                                .addCode("super($T.class);", typeBuilderName).build()
+		ClassName typeBuilderName = ClassName.get("", typeBuilder.build().name);
+		TypeSpec.Builder builder = TypeSpec.classBuilder(serializerName).addModifiers(Modifier.STATIC, Modifier.PUBLIC)
+				.superclass(ParameterizedTypeName.get(ClassName.get(StdSerializer.class), typeBuilderName))
+				.addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC).addCode("super($T.class);", typeBuilderName).build()
 
-                ).addModifiers(Modifier.PUBLIC);
-        MethodSpec.Builder serialize = MethodSpec.methodBuilder("serialize")
-                .addModifiers(Modifier.PUBLIC)
-                .addParameter(ParameterSpec.builder(typeBuilderName, "object").build())
-                .addParameter(ParameterSpec.builder(ClassName.get(JsonGenerator.class), "jsonGenerator").build())
-                .addParameter(ParameterSpec.builder(ClassName.get(SerializerProvider.class), "jsonSerializerProvider").build())
-                .addException(IOException.class)
-                .addException(JsonProcessingException.class);
+				).addModifiers(Modifier.PUBLIC);
+		MethodSpec.Builder serialize = MethodSpec.methodBuilder("serialize").addModifiers(Modifier.PUBLIC).addParameter(ParameterSpec.builder(typeBuilderName, "object").build())
+				.addParameter(ParameterSpec.builder(ClassName.get(JsonGenerator.class), "jsonGenerator").build())
+				.addParameter(ParameterSpec.builder(ClassName.get(SerializerProvider.class), "jsonSerializerProvider").build()).addException(IOException.class)
+				.addException(JsonProcessingException.class);
 
-        for (TypeDeclaration typeDeclaration : union.of()) {
+		for (TypeDeclaration typeDeclaration : union.of()) {
 
-            String isMethod = Names.methodName("is", typeDeclaration.name());
-            String getMethod = Names.methodName("get", typeDeclaration.name());
-            serialize.beginControlFlow("if ( object." + isMethod + "())");
-            serialize.addStatement("jsonGenerator.writeObject(object." + getMethod + "())");
-            serialize.addStatement("return");
-            serialize.endControlFlow();
-        }
+			String isMethod = Names.methodName("is", typeDeclaration.name());
+			String getMethod = Names.methodName("get", typeDeclaration.name());
+			serialize.beginControlFlow("if ( object." + isMethod + "())");
+			serialize.addStatement("jsonGenerator.writeObject(object." + getMethod + "())");
+			serialize.addStatement("return");
+			serialize.endControlFlow();
+		}
 
-        serialize.addStatement("throw new $T($S + object)", IOException.class, "Can't figure out type of object");
+		serialize.addStatement("throw new $T($S + object)", IOException.class, "Can't figure out type of object");
 
-        builder.addMethod(serialize.build());
-        typeBuilder.addType(builder.build());
-    }
+		builder.addMethod(serialize.build());
+		typeBuilder.addType(builder.build());
+	}
 
-    private void createDeserializer(UnionPluginContext unionPluginContext, ClassName serializerName, UnionTypeDeclaration union, TypeSpec.Builder typeBuilder, EventType eventType) {
+	private void createDeserializer(UnionPluginContext unionPluginContext, ClassName serializerName, UnionTypeDeclaration union, TypeSpec.Builder typeBuilder,
+			EventType eventType) {
 
-        if ( eventType == EventType.IMPLEMENTATION) {
-            return;
-        }
+		if (eventType == EventType.IMPLEMENTATION) {
+			return;
+		}
 
-        ClassName typeBuilderName = ClassName.get("", typeBuilder.build().name);
+		ClassName typeBuilderName = ClassName.get("", typeBuilder.build().name);
 
-        TypeSpec.Builder builder = TypeSpec.classBuilder(serializerName)
-                .addModifiers(Modifier.STATIC, Modifier.PUBLIC)
-                .superclass(ParameterizedTypeName.get(ClassName.get(StdDeserializer.class), typeBuilderName))
-                .addMethod(
-                        MethodSpec.constructorBuilder()
-                                .addModifiers(Modifier.PUBLIC)
-                                .addCode("super($T.class);", typeBuilderName).build()
+		TypeSpec.Builder builder = TypeSpec.classBuilder(serializerName).addModifiers(Modifier.STATIC, Modifier.PUBLIC)
+				.superclass(ParameterizedTypeName.get(ClassName.get(StdDeserializer.class), typeBuilderName))
+				.addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC).addCode("super($T.class);", typeBuilderName).build()
 
-                ).addModifiers(Modifier.PUBLIC);
+				).addModifiers(Modifier.PUBLIC);
 
-        MethodSpec.Builder deserialize = MethodSpec.methodBuilder("deserialize")
-                .addModifiers(Modifier.PUBLIC)
-                .addParameter(ParameterSpec.builder(ClassName.get(JsonParser.class), "jsonParser").build())
-                .addParameter(ParameterSpec.builder(ClassName.get(DeserializationContext.class), "jsonContext").build())
-                .addException(IOException.class)
-                .addException(JsonProcessingException.class)
-                .returns(typeBuilderName)
-                .addStatement("$T mapper  = new $T()", ObjectMapper.class, ObjectMapper.class)
-                .addStatement("$T<String, Object> map = mapper.readValue(jsonParser, Map.class)", Map.class);
+		MethodSpec.Builder deserialize = MethodSpec.methodBuilder("deserialize").addModifiers(Modifier.PUBLIC)
+				.addParameter(ParameterSpec.builder(ClassName.get(JsonParser.class), "jsonParser").build())
+				.addParameter(ParameterSpec.builder(ClassName.get(DeserializationContext.class), "jsonContext").build()).addException(IOException.class)
+				.addException(JsonProcessingException.class).returns(typeBuilderName).addStatement("$T mapper  = new $T()", ObjectMapper.class, ObjectMapper.class)
+				.addStatement("$T<String, Object> map = mapper.readValue(jsonParser, Map.class)", Map.class);
 
+		List<TypeDeclaration> unionOf = union.of();
 
-        List<TypeDeclaration> unionOf = union.of();
+		for (TypeDeclaration typeDeclaration : unionOf) {
 
-        for (TypeDeclaration typeDeclaration : unionOf) {
+			String name = Names.methodName("looksLike", typeDeclaration.name());
+			if (typeDeclaration instanceof ObjectTypeDeclaration && ((ObjectTypeDeclaration) typeDeclaration).discriminator() != null) {
 
+				TypeDeclaration parentType = findParentType(typeDeclaration);
+				TypeName unionPossibility = unionPluginContext.unionClass(typeDeclaration).getJavaName(EventType.INTERFACE);
+				ClassName javaName = unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION);
+				deserialize.addStatement("if ( " + name + "(map) ) return new $T(($T)mapper.convertValue(map, $T.class))", javaName, unionPossibility,
+						unionPluginContext.unionClass(parentType).getJavaName(EventType.INTERFACE));
+			} else {
+				TypeName unionPossibility = unionPluginContext.unionClass(typeDeclaration).getJavaName(EventType.IMPLEMENTATION);
+				deserialize.addStatement("if ( " + name + "(map) ) return new $T(mapper.convertValue(map, $T.class))",
+						unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), unionPossibility);
+			}
 
-            String name = Names.methodName("looksLike", typeDeclaration.name());
-            if ( typeDeclaration instanceof ObjectTypeDeclaration && ((ObjectTypeDeclaration)typeDeclaration).discriminator() != null ) {
+			buildLooksLike(builder, typeDeclaration);
+		}
 
-                TypeDeclaration parentType = findParentType(typeDeclaration);
-                TypeName unionPossibility = unionPluginContext.unionClass(typeDeclaration).getJavaName(EventType.INTERFACE);
-                ClassName javaName = unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION);
-                deserialize.addStatement("if ( " + name + "(map) ) return new $T(($T)mapper.convertValue(map, $T.class))",
-                        javaName,  unionPossibility,  unionPluginContext.unionClass(parentType).getJavaName(EventType.INTERFACE));
-            } else {
-                TypeName unionPossibility = unionPluginContext.unionClass(typeDeclaration).getJavaName(EventType.IMPLEMENTATION);
-                deserialize.addStatement("if ( " + name + "(map) ) return new $T(mapper.convertValue(map, $T.class))",
-                        unionPluginContext.creationResult().getJavaName(EventType.IMPLEMENTATION), unionPossibility);
-            }
+		deserialize.addStatement("throw new $T($S + map)", IOException.class, "Can't figure out type of object");
+		builder.addMethod(deserialize.build());
 
-            buildLooksLike(builder, typeDeclaration);
-        }
+		typeBuilder.addType(builder.build());
+	}
 
+	private TypeDeclaration findParentType(TypeDeclaration typeDeclaration) {
 
+		if (typeDeclaration instanceof ObjectTypeDeclaration) {
+			ObjectTypeDeclaration otd = (ObjectTypeDeclaration) typeDeclaration;
+			return otd.parentTypes().size() > 0 ? otd.parentTypes().get(0) : otd;
+		} else {
 
-        deserialize.addStatement("throw new $T($S + map)", IOException.class, "Can't figure out type of object");
-        builder.addMethod(deserialize.build());
+			return typeDeclaration;
+		}
+	}
 
-        typeBuilder.addType(builder.build());
-    }
+	private void buildLooksLike(TypeSpec.Builder builder, TypeDeclaration typeDeclaration) {
 
-    private TypeDeclaration findParentType(TypeDeclaration typeDeclaration) {
+		String name = Names.methodName("looksLike", typeDeclaration.name());
+		MethodSpec.Builder spec = MethodSpec.methodBuilder(name)
+				.addParameter(ParameterizedTypeName.get(ClassName.get(Map.class), ClassName.get(String.class), ClassName.get(Object.class)), "map");
+		if (typeDeclaration instanceof ObjectTypeDeclaration) {
 
-        if ( typeDeclaration instanceof ObjectTypeDeclaration ) {
-            ObjectTypeDeclaration otd = (ObjectTypeDeclaration) typeDeclaration;
-            return otd.parentTypes().size() > 0 ?otd.parentTypes().get(0):otd;
-        } else {
+			ObjectTypeDeclaration otd = (ObjectTypeDeclaration) typeDeclaration;
+			List<TypeDeclaration> mandatoryProperties = otd.properties().stream().filter(propertyTypeDeclaration -> propertyTypeDeclaration.required())
+					.collect(Collectors.toList());
+			if (otd.discriminator() != null) {
 
-            return typeDeclaration;
-        }
-    }
+				List<String> names = Lists.transform(mandatoryProperties, new Function<TypeDeclaration, String>() {
 
-    private void buildLooksLike(TypeSpec.Builder builder, TypeDeclaration typeDeclaration) {
+					@Nullable
+					@Override
+					public String apply(@Nullable TypeDeclaration input) {
+						return "\"" + input.name() + "\"";
+					}
+				});
 
-        String name = Names.methodName("looksLike", typeDeclaration.name());
-        MethodSpec.Builder spec =
-                MethodSpec.methodBuilder(name).addParameter(ParameterizedTypeName.get(ClassName.get(Map.class),
-                        ClassName.get(String.class),
-                        ClassName.get(Object.class)), "map");
-        if (typeDeclaration instanceof ObjectTypeDeclaration) {
+				spec.addStatement("return map.keySet().containsAll($T.asList($L)) && map.get($S).equals($S)", Arrays.class, Joiner.on(",").join(names), otd.discriminator(),
+						Optional.ofNullable(otd.discriminatorValue()).orElse(otd.name()));
 
-            ObjectTypeDeclaration otd = (ObjectTypeDeclaration) typeDeclaration;
-            if ( otd.discriminator() != null ) {
+			} else {
+				List<String> names = Lists.transform(mandatoryProperties, new Function<TypeDeclaration, String>() {
 
-                List<String> names = Lists.transform(otd.properties(), new Function<TypeDeclaration, String>() {
+					@Nullable
+					@Override
+					public String apply(@Nullable TypeDeclaration input) {
+						return "\"" + input.name() + "\"";
+					}
+				});
 
-                    @Nullable
-                    @Override
-                    public String apply(@Nullable TypeDeclaration input) {
-                        return "\"" + input.name() + "\"";
-                    }
-                });
+				spec.addStatement("return map.keySet().containsAll($T.asList($L))", Arrays.class, Joiner.on(",").join(names));
+			}
+		}
 
-                spec.addStatement("return map.keySet().containsAll($T.asList($L)) && map.get($S).equals($S)", Arrays.class, Joiner.on(",").join(names), otd.discriminator(), Optional.ofNullable(otd.discriminatorValue()).orElse(otd.name()));
-
-            } else {
-                List<String> names = Lists.transform(otd.properties(), new Function<TypeDeclaration, String>() {
-
-                    @Nullable
-                    @Override
-                    public String apply(@Nullable TypeDeclaration input) {
-                        return "\"" + input.name() + "\"";
-                    }
-                });
-
-                spec.addStatement("return map.keySet().containsAll($T.asList($L))", Arrays.class, Joiner.on(",").join(names));
-            }
-        }
-
-        spec.addModifiers(Modifier.PRIVATE).returns(TypeName.BOOLEAN);
-        builder.addMethod(spec.build());
-    }
+		spec.addModifiers(Modifier.PRIVATE).returns(TypeName.BOOLEAN);
+		builder.addMethod(spec.build());
+	}
 
 }


### PR DESCRIPTION
The current buildLooksLike code verifies the document to deserialize contains all the properties (required and non-required) from the RAML object declaration. This causes the object identification (and thereby the deserialization) to fail if any of the non-required properties is missing from the response document.

By adding the following code only the mandatory properties are verified:

```
List<TypeDeclaration> mandatoryProperties = otd.properties().stream().filter(propertyTypeDeclaration -> propertyTypeDeclaration.required())
					.collect(Collectors.toList());
```

This results into code like the following (with no optional attributes in the containsAll):

```
    private boolean looksLikeMortgageAccount(Map<String, Object> map) {
      return map.keySet().containsAll(Arrays.asList("accountId","type")) && map.get("type").equals("MORTGAGE");
    }
```

Apologies for the automated code formatting.