### PR TITLE
#52 Add full constuctor to generated "impl" classes

### DIFF
--- a/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/constructor/ConstructorExtension.java
+++ b/raml-to-pojo/src/main/java/org/raml/ramltopojo/extensions/constructor/ConstructorExtension.java
@@ -1,0 +1,65 @@
+package org.raml.ramltopojo.extensions.constructor;
+
+import java.util.Objects;
+
+import javax.lang.model.element.Modifier;
+
+import org.raml.ramltopojo.EcmaPattern;
+import org.raml.ramltopojo.EventType;
+import org.raml.ramltopojo.Names;
+import org.raml.ramltopojo.extensions.ObjectPluginContext;
+import org.raml.ramltopojo.extensions.ObjectTypeHandlerPlugin;
+import org.raml.v2.api.model.v10.datamodel.ObjectTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.TypeDeclaration;
+
+import com.google.common.base.Optional;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+
+public class ConstructorExtension extends ObjectTypeHandlerPlugin.Helper {
+	
+  @Override
+  public TypeSpec.Builder classCreated(ObjectPluginContext objectPluginContext, ObjectTypeDeclaration ramlType, TypeSpec.Builder typeSpec, EventType eventType) {
+     
+    if (eventType != EventType.IMPLEMENTATION) {
+      return typeSpec;
+    }
+    
+    boolean hasConstructorParams = false;
+    TypeSpec clazz = typeSpec.build();
+    MethodSpec.Builder fullConstructor = MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC);
+    Optional<String> discriminator = Optional.fromNullable(ramlType.discriminator());
+    
+    for (TypeDeclaration propertyDeclaration : ramlType.properties()) {
+
+	    if (EcmaPattern.isSlashedPattern(propertyDeclaration.name()) || Objects.equals(propertyDeclaration.name(), discriminator.orNull())) {
+	      continue;
+	    }
+	    	    
+      fullConstructor
+	      .addCode(CodeBlock.builder().addStatement("this." + Names.variableName(propertyDeclaration.name()) + " = " + Names.variableName(propertyDeclaration.name())).build())
+	      .addParameter(findField(clazz, propertyDeclaration), Names.variableName(propertyDeclaration.name()));
+      
+      hasConstructorParams = true;
+    }
+    
+    if (hasConstructorParams) {
+      typeSpec.addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC).build());
+      typeSpec.addMethod(fullConstructor.build());
+    }
+  	
+  	return typeSpec;
+  }
+  
+  private TypeName findField(final TypeSpec clazz, final TypeDeclaration field) {
+  	for (FieldSpec fieldSpec : clazz.fieldSpecs) {
+  		if (Objects.equals(field.name(), fieldSpec.name)) {
+  			return fieldSpec.type;
+  		}
+  	}
+  	throw new IllegalArgumentException("There is no field of name: " + field.name());
+  }
+}

--- a/raml-to-pojo/src/main/resources/META-INF/ramltopojo-plugin.properties
+++ b/raml-to-pojo/src/main/resources/META-INF/ramltopojo-plugin.properties
@@ -47,3 +47,5 @@ core.suppressType=org.raml.ramltopojo.extensions.tools.SuppressTypePlugin
 core.wildcardcollection=org.raml.ramltopojo.extensions.tools.CovariantListPlugin
 
 core.chainSetter=org.raml.ramltopojo.extensions.tools.ChainSetter
+
+core.constructor=org.raml.ramltopojo.extensions.constructor.ConstructorExtension

--- a/raml-to-pojo/src/test/java/org/raml/ramltopojo/extensions/constructor/ConstructorExtensionTest.java
+++ b/raml-to-pojo/src/test/java/org/raml/ramltopojo/extensions/constructor/ConstructorExtensionTest.java
@@ -1,0 +1,168 @@
+package org.raml.ramltopojo.extensions.constructor;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static com.squareup.javapoet.Assertions.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+import static org.raml.ramltopojo.RamlLoader.findTypes;
+import static org.raml.testutils.matchers.FieldSpecMatchers.fieldName;
+import static org.raml.testutils.matchers.FieldSpecMatchers.fieldType;
+import static org.raml.testutils.matchers.FieldSpecMatchers.initializer;
+import static org.raml.testutils.matchers.MethodSpecMatchers.codeContent;
+import static org.raml.testutils.matchers.MethodSpecMatchers.methodName;
+import static org.raml.testutils.matchers.MethodSpecMatchers.parameters;
+import static org.raml.testutils.matchers.MethodSpecMatchers.returnType;
+import static org.raml.testutils.matchers.ParameterSpecMatchers.type;
+import static org.raml.testutils.matchers.TypeNameMatcher.typeName;
+import static org.raml.testutils.matchers.TypeSpecMatchers.fields;
+import static org.raml.testutils.matchers.TypeSpecMatchers.methods;
+import static org.raml.testutils.matchers.TypeSpecMatchers.name;
+import static org.raml.testutils.matchers.TypeSpecMatchers.superInterfaces;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.raml.ramltopojo.CreationResult;
+import org.raml.ramltopojo.EventType;
+import org.raml.ramltopojo.GenerationContextImpl;
+import org.raml.ramltopojo.RamlLoader;
+import org.raml.ramltopojo.RamlToPojo;
+import org.raml.ramltopojo.RamlToPojoBuilder;
+import org.raml.ramltopojo.TypeFetchers;
+import org.raml.ramltopojo.TypeFinders;
+import org.raml.ramltopojo.extensions.ObjectPluginContext;
+import org.raml.ramltopojo.extensions.ObjectTypeHandlerPlugin;
+import org.raml.ramltopojo.object.ObjectTypeHandler;
+import org.raml.ramltopojo.plugin.PluginManager;
+import org.raml.testutils.assertj.ListAssert;
+import org.raml.v2.api.model.v10.api.Api;
+import org.raml.v2.api.model.v10.datamodel.ObjectTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.StringTypeDeclaration;
+import org.raml.v2.api.model.v10.datamodel.TypeDeclaration;
+
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+
+public class ConstructorExtensionTest {
+	
+	@Test
+  public void empty() throws Exception {
+
+    Api api = RamlLoader.load(this.getClass().getResourceAsStream("empty-type.raml"), ".");
+    RamlToPojo ramlToPojo = new RamlToPojoBuilder(api).fetchTypes(TypeFetchers.fromAnywhere()).findTypes(TypeFinders.everyWhere()).build(Arrays.asList("core.constructor"));
+    CreationResult r = ramlToPojo.buildPojos().creationResults().stream().filter(x -> x.getJavaName(EventType.INTERFACE).simpleName().equals("Foo")).findFirst().get();
+
+    assertThat(r.getInterface()).hasName("Foo");
+    
+    System.err.println(r.getInterface().toString());
+    System.err.println(r.getImplementation().toString());
+
+    assertThat(r.getImplementation().get(), is(allOf(
+	    name(equalTo("FooImpl")),
+	    methods(containsInAnyOrder(
+	      allOf(methodName(equalTo("getAdditionalProperties")), returnType(equalTo(ParameterizedTypeName.get(Map.class, String.class, Object.class)))),
+	      allOf(methodName(equalTo("setAdditionalProperties")), parameters(contains(type(equalTo(TypeName.get(String.class))), type(equalTo(TypeName.get(Object.class))))))
+	    ))                 
+    )));
+  }
+	
+	
+	@Test
+  public void simplest() throws Exception {
+
+    Api api = RamlLoader.load(this.getClass().getResourceAsStream("simplest-type.raml"), ".");
+    RamlToPojo ramlToPojo = new RamlToPojoBuilder(api).fetchTypes(TypeFetchers.fromAnywhere()).findTypes(TypeFinders.everyWhere()).build(Arrays.asList("core.constructor"));
+    CreationResult r = ramlToPojo.buildPojos().creationResults().stream().filter(x -> x.getJavaName(EventType.INTERFACE).simpleName().equals("Foo")).findFirst().get();
+
+    assertThat(r.getInterface()).hasName("Foo");
+    
+    System.err.println(r.getInterface().toString());
+    System.err.println(r.getImplementation().toString());
+
+    assertThat(r.getImplementation().get(), is(allOf(
+	    name(equalTo("FooImpl")),
+	    methods(containsInAnyOrder(
+        allOf(methodName(equalTo("<init>"))),
+        allOf(methodName(equalTo("<init>")), parameters(contains(type(equalTo(ClassName.get(String.class))), type(equalTo(ClassName.INT))))),	    	
+	      allOf(methodName(equalTo("getName")), returnType(equalTo(ClassName.get(String.class)))),
+	      allOf(methodName(equalTo("setName")), parameters(contains(type(equalTo(ClassName.get(String.class)))))),
+	      allOf(methodName(equalTo("getAge")), returnType(equalTo(ClassName.INT))),
+	      allOf(methodName(equalTo("setAge")), parameters(contains(type(equalTo(ClassName.INT)))))
+	    ))                 
+    )));
+  }
+
+  @Test
+  public void composed() throws Exception {
+    
+  	Api api = RamlLoader.load(this.getClass().getResourceAsStream("composed-type.raml"), ".");
+    RamlToPojo ramlToPojo = new RamlToPojoBuilder(api).fetchTypes(TypeFetchers.fromAnywhere()).findTypes(TypeFinders.everyWhere()).build(Arrays.asList("core.constructor"));
+    CreationResult r = ramlToPojo.buildPojos().creationResults().stream().filter(x -> x.getJavaName(EventType.INTERFACE).simpleName().equals("Foo")).findFirst().get();
+
+    assertThat(r.getInterface()).hasName("Foo");
+    
+    System.err.println(r.getInterface().toString());
+    System.err.println(r.getImplementation().toString());
+
+    assertThat(r.getImplementation().get(), is(allOf(
+      name(equalTo("FooImpl")),
+      methods(containsInAnyOrder(
+        allOf(methodName(equalTo("<init>"))),
+        allOf(methodName(equalTo("<init>")), parameters(contains(type(equalTo(ClassName.get("", "Composed")))))),
+        allOf(methodName(equalTo("getName")), returnType(equalTo(ClassName.get("", "Composed")))),
+        allOf(methodName(equalTo("setName")), parameters(contains(type(equalTo(ClassName.get("", "Composed"))))))
+      ))
+    )));
+  }
+
+  @Test
+  public void discriminator() throws Exception {
+
+  	Api api = RamlLoader.load(this.getClass().getResourceAsStream("discriminator-type.raml"), ".");
+    RamlToPojo ramlToPojo = new RamlToPojoBuilder(api).fetchTypes(TypeFetchers.fromAnywhere()).findTypes(TypeFinders.everyWhere()).build(Arrays.asList("core.constructor"));
+    CreationResult r = ramlToPojo.buildPojos().creationResults().stream().filter(x -> x.getJavaName(EventType.INTERFACE).simpleName().equals("Foo")).findFirst().get();
+
+    assertThat(r.getInterface()).hasName("Foo");
+    
+    System.err.println(r.getInterface().toString());
+    System.err.println(r.getImplementation().toString());
+    
+	  assertThat(r.getImplementation().get(), is(allOf(
+	    name(equalTo("FooImpl")),
+	    methods(containsInAnyOrder(
+        allOf(methodName(equalTo("<init>"))),
+        allOf(methodName(equalTo("<init>")), parameters(contains(type(equalTo(ClassName.get(String.class))), type(equalTo(ClassName.get(String.class)))))),
+	      allOf(methodName(equalTo("getAdditionalProperties")), returnType(equalTo(ParameterizedTypeName.get(Map.class, String.class, Object.class)))),
+	      allOf(methodName(equalTo("setAdditionalProperties")), parameters(contains(type(equalTo(TypeName.get(String.class))), type(equalTo(TypeName.get(Object.class)))))),
+	      allOf(methodName(equalTo("getKind")), returnType(equalTo(ClassName.get(String.class)))),
+	      allOf(methodName(equalTo("getRight")), returnType(equalTo(ClassName.get(String.class)))),
+	      allOf(methodName(equalTo("setRight")), parameters(contains(type(equalTo(ClassName.get(String.class)))))),
+	      allOf(methodName(equalTo("getName")), returnType(equalTo(ClassName.get(String.class)))),
+	      allOf(methodName(equalTo("setName")), parameters(contains(type(equalTo(ClassName.get(String.class))))))
+	    ))
+    )));
+  }
+}

--- a/raml-to-pojo/src/test/resources/org/raml/ramltopojo/extensions/constructor/composed-type.raml
+++ b/raml-to-pojo/src/test/resources/org/raml/ramltopojo/extensions/constructor/composed-type.raml
@@ -1,0 +1,15 @@
+#%RAML 1.0
+title: Hello World API
+version: v1
+baseUri: https://api.github.com
+types:
+    composed:
+      additionalProperties: false
+      properties:
+        size: integer
+    foo:
+        additionalProperties: false
+        type: object
+        properties:
+          name: composed
+

--- a/raml-to-pojo/src/test/resources/org/raml/ramltopojo/extensions/constructor/discriminator-type.raml
+++ b/raml-to-pojo/src/test/resources/org/raml/ramltopojo/extensions/constructor/discriminator-type.raml
@@ -1,0 +1,15 @@
+#%RAML 1.0
+title: Hello World API
+version: v1
+baseUri: https://api.github.com
+types:
+    once:
+      discriminator: kind
+      properties:
+        kind: string
+        right: string
+    foo:
+        type: once
+        properties:
+          name: string
+

--- a/raml-to-pojo/src/test/resources/org/raml/ramltopojo/extensions/constructor/empty-type.raml
+++ b/raml-to-pojo/src/test/resources/org/raml/ramltopojo/extensions/constructor/empty-type.raml
@@ -1,0 +1,8 @@
+#%RAML 1.0
+title: Hello World API
+version: v1
+baseUri: https://api.github.com
+types:
+    foo:
+        type: object
+

--- a/raml-to-pojo/src/test/resources/org/raml/ramltopojo/extensions/constructor/simplest-type.raml
+++ b/raml-to-pojo/src/test/resources/org/raml/ramltopojo/extensions/constructor/simplest-type.raml
@@ -1,0 +1,11 @@
+#%RAML 1.0
+title: Hello World API
+version: v1
+baseUri: https://api.github.com
+types:
+    foo:
+        additionalProperties: false
+        type: object
+        properties:
+          name: string
+          age: integer


### PR DESCRIPTION
Added a constructor with all fields and adjusted corresponding tests of Objects. Constructor will only be generated for implementation classes. Additional properties will be ignored.
Also added an empty constructor for jackson geneneration and to not break current behaviour.